### PR TITLE
Allow author taxonomy

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -55,12 +55,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/newspack-migration-tools.git",
-                "reference": "05422f3fda8484707cc3502885eed47be3c2116a"
+                "reference": "7fbd797d9dd2ea61e3d2627db90ef01417938b89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/newspack-migration-tools/zipball/05422f3fda8484707cc3502885eed47be3c2116a",
-                "reference": "05422f3fda8484707cc3502885eed47be3c2116a",
+                "url": "https://api.github.com/repos/Automattic/newspack-migration-tools/zipball/7fbd797d9dd2ea61e3d2627db90ef01417938b89",
+                "reference": "7fbd797d9dd2ea61e3d2627db90ef01417938b89",
                 "shasum": ""
             },
             "require": {
@@ -114,7 +114,7 @@
                 "source": "https://github.com/Automattic/newspack-migration-tools/tree/trunk",
                 "issues": "https://github.com/Automattic/newspack-migration-tools/issues"
             },
-            "time": "2025-09-19T17:09:14+00:00"
+            "time": "2025-10-02T12:52:47+00:00"
         },
         {
             "name": "bramus/ansi-php",

--- a/newspack-content-diff-migrator.php
+++ b/newspack-content-diff-migrator.php
@@ -5,7 +5,7 @@
  * Plugin URI:  https://newspack.com
  * Author:      Automattic
  * Author URI:  https://newspack.com
- * Version:     1.0.0
+ * Version:     1.0.1
  *
  * @package  Newspack_Content_Diff_Migrator
  */

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -164,7 +164,7 @@ class ContentDiffMigrator {
 					[
 						'type'        => 'assoc',
 						'name'        => 'custom-taxonomies-csv',
-						'description' => 'CSV of all the taxonomies to import, no extra spaces. NOTE, if you are modifying this list, make sure to include category and post_tag or else these will not be migrated. E.g. --custom-taxonomies-csv=post_tag,category,brand,custom_taxonomy.',
+						'description' => 'CSV of all the taxonomies to import, no extra spaces. NOTE, if you are modifying this list, make sure to include category,post_tag,author or else these will not be migrated. E.g. --custom-taxonomies-csv=post_tag,category,author,brand,custom_taxonomy.',
 						'optional'    => true,
 						'repeating'   => false,
 					],
@@ -370,7 +370,9 @@ class ContentDiffMigrator {
 
 		$import_dir            = $assoc_args['import-dir'] ?? false;
 		$live_table_prefix     = $assoc_args['live-table-prefix'] ?? false;
-		$taxonomies_to_migrate = isset( $assoc_args['custom-taxonomies-csv'] ) ? explode( ',', $assoc_args['custom-taxonomies-csv'] ) : [ 'category', 'post_tag' ];
+
+		// Default taxonomies which are migrated are defined here.
+		$taxonomies_to_migrate = isset( $assoc_args['custom-taxonomies-csv'] ) ? explode( ',', $assoc_args['custom-taxonomies-csv'] ) : [ 'category', 'post_tag', 'author' ];
 
 		// Validate all params.
 		$file_ids_csv      = $import_dir . '/' . self::LOG_IDS_CSV;
@@ -384,13 +386,16 @@ class ContentDiffMigrator {
 			WP_CLI::error( sprintf( 'File %s does not contain valid CSV IDs.', $file_ids_csv ) );
 		}
 
-		// In case some custom taxonomies were provided, but category or post_tag were not among those, warn the user that they won't be migrated and ask for confirmation to continue.
+		// In case some custom taxonomies were provided, but category,post_tag,author were not among those, warn the user that they won't be migrated and ask for confirmation to continue.
 		if ( ! empty( $assoc_args['custom-taxonomies-csv'] ) ) {
 			if ( ! in_array( 'category', $taxonomies_to_migrate ) ) {
 				WP_CLI::confirm( 'Warning, category was not given in --custom-taxonomies-csv argument and so categories will not be migrated. Continue?' );
 			}
 			if ( ! in_array( 'post_tag', $taxonomies_to_migrate ) ) {
 				WP_CLI::confirm( 'Warning, post_tag was not given in --custom-taxonomies-csv argument and so tags will not be migrated. Continue?' );
+			}
+			if ( ! in_array( 'author', $taxonomies_to_migrate ) ) {
+				WP_CLI::confirm( 'Warning, author was not given in --custom-taxonomies-csv argument and so co-authors will not be migrated. Continue?' );
 			}
 		}
 

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -368,8 +368,8 @@ class ContentDiffMigrator {
 	public function cmd_migrate_live_content( $args, $assoc_args ) {
 		global $wpdb;
 
-		$import_dir            = $assoc_args['import-dir'] ?? false;
-		$live_table_prefix     = $assoc_args['live-table-prefix'] ?? false;
+		$import_dir        = $assoc_args['import-dir'] ?? false;
+		$live_table_prefix = $assoc_args['live-table-prefix'] ?? false;
 
 		// Default taxonomies which are migrated are defined here.
 		$taxonomies_to_migrate = isset( $assoc_args['custom-taxonomies-csv'] ) ? explode( ',', $assoc_args['custom-taxonomies-csv'] ) : [ 'category', 'post_tag', 'author' ];

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -383,10 +383,6 @@ class ContentDiffMigrator {
 		if ( empty( $all_live_posts_ids ) ) {
 			WP_CLI::error( sprintf( 'File %s does not contain valid CSV IDs.', $file_ids_csv ) );
 		}
-		// Disable CAP's "author" taxonomy.
-		if ( in_array( 'author', $taxonomies_to_migrate ) ) {
-			WP_CLI::error( "CAP's 'author' taxonomy is not supported at this point as CAP data requires a dedicated migrator for its complexity and special cases. Please remove 'author' from the list of taxonomies to migrate and re-run the command." );
-		}
 
 		// In case some custom taxonomies were provided, but category or post_tag were not among those, warn the user that they won't be migrated and ask for confirmation to continue.
 		if ( ! empty( $assoc_args['custom-taxonomies-csv'] ) ) {

--- a/src/Logic/ContentDiffMigrator.php
+++ b/src/Logic/ContentDiffMigrator.php
@@ -765,7 +765,7 @@ class ContentDiffMigrator {
 	 *
 	 * @return array|null {
 	 *     @type string term_id     Term term_id.
-	 *     @type string taxonomy    Term taxonomy, e.g. 'category' or 'post_tag'.
+	 *     @type string taxonomy    Term taxonomy, e.g. 'category' or 'post_tag' or 'author'.
 	 *     @type string name        Term name.
 	 *     @type string slug        Term slug.
 	 *     @type string description Taxonomy description.


### PR DESCRIPTION
## Description
There are two stop signs presently in the CDiff command for migrating CAP things:
- if you try and add `guest-author` CPT to custom list of CPTs to migrate, it stops it with a CAP-disclaimer message
- same if you try and add `guest` taxonomy

This PR now allows migrating `guest` taxonomy, for several reasons:
- unlike "guest-author" CPTs, which are not longer supported by Newspack, we do use author taxonomy actively for co-author assignments
- but unlike CPTs, the taxonomy is totally safe -- CDiff simply adds the taxonomy, terms and term relationships
- CPT "guest-author" still remains blocked
- this was tested on multiple launched sites

It also makes `author` taxonomy one of the three default taxonomies to automatically migrate `category,post_tag,author`.

---

- [x] confirmed that PHPCS has been run
