### PR TITLE
Remove block for CAP Guest Authors to be migrated

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This plugin operates exclusively through WP-CLI commands. It's designed to be ru
 wp newspack-content-migrator content-diff-search-new-content-on-live \
 --live-table-prefix=live_ \
 --export-dir=/tmp/cdiff_data \
-[--post-types-csv=post,page,attachment,custom_cpt]
+[--post-types-csv=post,page,attachment,custom_cpt1,custom_cpt2,guest-author]
 ```
 4. **Migrate Content**: Import the identified content differential to the local site
 ```

--- a/composer.lock
+++ b/composer.lock
@@ -55,12 +55,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/newspack-migration-tools.git",
-                "reference": "9f62b779abf0fcd64f4a10ca899e21fe06e0ddea"
+                "reference": "86f9081e7d0da06632ff0afea3155c04ebaed1ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/newspack-migration-tools/zipball/9f62b779abf0fcd64f4a10ca899e21fe06e0ddea",
-                "reference": "9f62b779abf0fcd64f4a10ca899e21fe06e0ddea",
+                "url": "https://api.github.com/repos/Automattic/newspack-migration-tools/zipball/86f9081e7d0da06632ff0afea3155c04ebaed1ea",
+                "reference": "86f9081e7d0da06632ff0afea3155c04ebaed1ea",
                 "shasum": ""
             },
             "require": {
@@ -118,7 +118,7 @@
                 "source": "https://github.com/Automattic/newspack-migration-tools/tree/trunk",
                 "issues": "https://github.com/Automattic/newspack-migration-tools/issues"
             },
-            "time": "2025-11-14T14:04:59+00:00"
+            "time": "2025-12-03T10:57:30+00:00"
         },
         {
             "name": "bramus/ansi-php",

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -134,9 +134,10 @@ class ContentDiffMigrator {
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-types-csv',
-						'description' => 'CSV of all the post types to scan, no extra spaces. E.g. --post-types-csv=post,page,attachment,some_cpt. Default value is post,attachment.',
+						'description' => 'CSV of all the post types to scan, no extra spaces. E.g. --post-types-csv=post,page,attachment,custom_cpt1. Note: For CoAuthors Plus Guest Authors support, include guest-author CPT, and in the migrate command make sure author taxonomy is migrated (author taxonomy is already a default value in --custom-taxonomies-csv).',
 						'optional'    => true,
 						'repeating'   => false,
+						'default'     => 'post,attachment',
 					],
 				],
 			]
@@ -164,9 +165,10 @@ class ContentDiffMigrator {
 					[
 						'type'        => 'assoc',
 						'name'        => 'custom-taxonomies-csv',
-						'description' => 'CSV of all the taxonomies to import, no extra spaces. NOTE, if you are modifying this list, make sure to include category,post_tag,author or else these will not be migrated. E.g. --custom-taxonomies-csv=post_tag,category,author,brand,custom_taxonomy.',
+						'description' => 'CSV of all the taxonomies to import. If you are adding custom taxonomies and modifying this list, make sure to include default WP taxonomies (category,post_tag,author), e.g. --custom-taxonomies-csv=post_tag,category,author,brand,custom_taxonomy.',
 						'optional'    => true,
 						'repeating'   => false,
+						'default'     => 'post_tag,category,author',
 					],
 				],
 			]
@@ -256,11 +258,7 @@ class ContentDiffMigrator {
 	public function cmd_search_new_content_on_live( $args, $assoc_args ) {
 		$export_dir        = $assoc_args['export-dir'] ?? false;
 		$live_table_prefix = $assoc_args['live-table-prefix'] ?? false;
-		$post_types        = isset( $assoc_args['post-types-csv'] ) ? explode( ',', $assoc_args['post-types-csv'] ) : [ 'post', 'attachment' ];
-		// Disable CAP's "guest-author" CPT.
-		if ( in_array( 'guest-author', $post_types ) ) {
-			WP_CLI::error( "CAP's 'guest-author' CPT is not supported at this point as CAP data requires a dedicated migrator for its complexity and special cases. Please remove 'guest-author' from the list of CPTs to migrate and re-run the command." );
-		}
+		$post_types        = explode( ',', $assoc_args['post-types-csv'] );
 
 		global $wpdb;
 		try {
@@ -371,8 +369,8 @@ class ContentDiffMigrator {
 		$import_dir        = $assoc_args['import-dir'] ?? false;
 		$live_table_prefix = $assoc_args['live-table-prefix'] ?? false;
 
-		// Default taxonomies which are migrated are defined here.
-		$taxonomies_to_migrate = isset( $assoc_args['custom-taxonomies-csv'] ) ? explode( ',', $assoc_args['custom-taxonomies-csv'] ) : [ 'category', 'post_tag', 'author' ];
+		// Taxonomies which will be migrated.
+		$taxonomies_to_migrate = explode( ',', $assoc_args['custom-taxonomies-csv'] );
 
 		// Validate all params.
 		$file_ids_csv      = $import_dir . '/' . self::LOG_IDS_CSV;


### PR DESCRIPTION
## Description
CAP's Guest Authors Custom Post Type `guest-author` was blocked via hard code. This lets GAs be migrated if the user wishes to.

## How to migrate Guest Authors

1. In the first command to "search new content", in `--post-types-csv` add the GA CPT `guest-author`:
```
wp newspack-content-migrator content-diff-search-new-content-on-live \
--export-dir=/tmp \
--live-table-prefix=live_ \
--post-types-csv=post,attachment,guest-author
```

Because if `guest-authors` is not manually specified, it will not be migrated -- `'default' => 'post,attachment',` , @see this param definition.

2. The second "migrate" command's `--custom-taxonomies-csv` already contains `author` taxonomy by default. Nothing to do here.

---

- [x] confirmed that PHPCS has been run
