### PR TITLE
Resumable search command

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,14 +208,29 @@ wp newspack-content-diff-migrator correct-collations-for-live-wp-tables \
 The `--data-dir` parameter stores logs and run-state data in a `run-state` subfolder (e.g., `/tmp/cdiff_data/run-state/`).
 
 The run-state data includes:
-- **`manifest.json`** — Migration summary with
-  - timestamp
-  - source hostname
-  - post types
-  - counts of new/modified IDs
-  - Useful for quickly reviewing what was migrated.
+- **`manifest.json`** — Migration summary (see fields below)
 - **`new_ids.json`** / **`modified_ids.json`** — IDs to be imported or reimported
 - **`imported_posts.jsonl`**, **`updated_*.jsonl`** — Progress tracking files for resume capability
+
+### Manifest Fields
+
+Example `manifest.json`:
+
+```json
+{
+    "created_at": "2025-03-15 14:30:00",
+    "source_hostname": "www.example.com",
+    "search_status": "completed",
+    "migrate_status": "completed",
+    "live_table_prefix": "cdiff_",
+    "post_types": ["post", "page", "attachment", "wp_block"],
+    "taxonomies": ["category", "post_tag", "author", "brand"],
+    "counts": {
+        "new_ids": 150,
+        "modified_ids": 25
+    }
+}
+```
 
 ### Resuming an Interrupted Migration
 

--- a/composer.json
+++ b/composer.json
@@ -55,12 +55,14 @@
       ".travis.yml",
       ".git*",
       ".git/*",
+      ".github/*",
       ".distignore",
       ".DS_Store",
       ".env*",
       ".idea",
       "*.log*",
-      "release"
+      "release",
+      "pull_request_template.md"
     ]
   },
   "scripts": {
@@ -70,7 +72,7 @@
     "code-coverage-clover": "export XDEBUG_MODE=coverage && ./vendor/bin/phpunit --coverage-clover build/coverage_clover/clover.xml",
     "code-coverage-html": "export XDEBUG_MODE=coverage && ./vendor/bin/phpunit --coverage-html build/coverage_html",
     "build-release": [
-        "rm -rf vendor",
+        "rm -rf vendor 2>/dev/null || true",
         "rm -rf release",
         "composer install --no-dev --optimize-autoloader",
         "composer archive --format=zip --dir=release --file=newspack-content-diff-migrator"

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -347,28 +347,53 @@ class ContentDiffMigrator {
 		Logger::instance()->init( rtrim( $data_dir, '/' ) . '/' . __FUNCTION__ . '.log' );
 		Logger::instance()->log( Logger::OUTPUT_FILE, LogLevel::DEBUG, 'Starting command content-diff-search-new-content-on-live...' );
 
-		// Check if previous run-state exists. Warn and exit to protect previous logs and run-state data (useful for debugging and backtracking migrations).
-		// Skip in test environment to allow testing of multiple search cycles.
+		// Check if the run-state and a manifest exist from a previous interrupted command run and handle.
 		$existing_manifest = $this->run_state->get_manifest();
 		if ( ! $this->test_env && $existing_manifest ) {
 			$existing_source = $existing_manifest['source_hostname'] ?? 'unknown';
 			$existing_date   = $existing_manifest['created_at'] ?? 'unknown';
+			$search_status   = $existing_manifest['search_status'] ?? null;
 
+			// Case 1: Different hostname - always refuse to proceed.
 			if ( $existing_source !== $source_hostname ) {
 				Logger::instance()->log(
 					Logger::OUTPUT_BOTH,
 					LogLevel::ERROR,
 					sprintf( 'This --data-dir contains run-state from a DIFFERENT source hostname (%s, created %s). Please use a new --data-dir.', $existing_source, $existing_date ) 
 				);
-			} else {
+				return;
+			}
+
+			// Case 2: Search already completed - nothing left to do.
+			if ( RunState::STATUS_COMPLETED === $search_status ) {
 				Logger::instance()->log(
 					Logger::OUTPUT_BOTH,
-					LogLevel::ERROR,
-					sprintf( 'This --data-dir contains run-state from a previous migration run (created %s). Please use a new --data-dir to preserve previous logs for debugging.', $existing_date ) 
+					LogLevel::INFO,
+					sprintf( 'Search already completed for this --data-dir (created %s). Nothing left to do.', $existing_date ) 
 				);
+				return;
 			}
-			return; // Exit early (a return is friendly to both CLI and test environments).
+
+			// Case 3: Same hostname, search not completed - allow re-run, begin by deleting previous partial state to start fresh.
+			Logger::instance()->log(
+				Logger::OUTPUT_BOTH,
+				LogLevel::DEBUG,
+				sprintf( 'Incomplete search detected (created %s). Deleting previous run-state and re-running...', $existing_date )
+			);
+			$this->run_state->delete_run_state();
 		}
+
+		// Write initial manifest with "started" status.
+		$this->run_state->write_manifest(
+			[
+				'created_at'        => gmdate( 'Y-m-d H:i:s' ),
+				'source_hostname'   => $source_hostname,
+				'search_status'     => RunState::STATUS_STARTED,
+				'live_table_prefix' => $live_table_prefix,
+				'post_types'        => $post_types,
+				// --custom-taxonomies-csv are used for auto-attribution in the search command. The migrate command uses --custom-taxonomies-csv to actually migrate defined taxonomies, which is where the "taxonomies" field will be recorded.
+			]
+		);
 
 		try {
 			$this->db->validate_db_tables( $live_table_prefix, [ 'options' ] );
@@ -567,16 +592,12 @@ class ContentDiffMigrator {
 			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::INFO, sprintf( 'List of modified IDs to reimport stored to run-state file %s', RunState::FILE_MODIFIED_IDS ) );
 		}
 
-		// Save manifest.json with migration TOC.
-		$manifest = [
-			'created_at'        => gmdate( 'Y-m-d H:i:s' ),
-			'source_hostname'   => $source_hostname,
-			'live_table_prefix' => $live_table_prefix,
-			'post_types'        => $post_types,
-			'counts'            => [
-				'new_ids'      => count( $new_live_ids ),
-				'modified_ids' => count( $modified_live_ids ),
-			],
+		// Update manifest with completed status and counts.
+		$manifest                  = $this->run_state->get_manifest() ?? [];
+		$manifest['search_status'] = RunState::STATUS_COMPLETED;
+		$manifest['counts']        = [
+			'new_ids'      => count( $new_live_ids ),
+			'modified_ids' => count( $modified_live_ids ),
 		];
 		$this->run_state->write_manifest( $manifest );
 
@@ -623,6 +644,43 @@ class ContentDiffMigrator {
 		// Set RunState on DataImporter for tracking users/terms.
 		$this->data_importer->set_run_state( $this->run_state );
 
+		// Read manifest (written by search command).
+		$manifest = $this->run_state->get_manifest();
+		if ( is_null( $manifest ) ) {
+			throw new \RuntimeException( sprintf( 'Can not find manifest file (%s). Run search-new-content-on-live first.', RunState::FILE_MANIFEST ) ); // phpcs:ignore -- exception message is for internal logging/debugging WordPress.Security.EscapeOutput.ExceptionNotEscaped.
+		}
+
+		// Check manifest for hostname mismatch or already completed status.
+		if ( ! $this->test_env ) {
+			$existing_source = $manifest['source_hostname'] ?? 'unknown';
+			$existing_date   = $manifest['created_at'] ?? 'unknown';
+			$migrate_status  = $manifest['migrate_status'] ?? null;
+
+			// Case 1: Different hostname - always refuse to proceed.
+			if ( $existing_source !== $source_hostname ) {
+				Logger::instance()->log(
+					Logger::OUTPUT_BOTH,
+					LogLevel::ERROR,
+					sprintf( 'This --data-dir contains run-state from a DIFFERENT source hostname (%s, created %s). Please use a new --data-dir.', $existing_source, $existing_date )
+				);
+				return;
+			}
+
+			// Case 2: Migrate already completed - nothing left to do.
+			if ( RunState::STATUS_COMPLETED === $migrate_status ) {
+				Logger::instance()->log(
+					Logger::OUTPUT_BOTH,
+					LogLevel::INFO,
+					sprintf( 'Migration already completed for this --data-dir (created %s). Nothing left to do.', $existing_date )
+				);
+				return;
+			}
+		}
+
+		// Set migrate_status to "started".
+		$manifest['migrate_status'] = RunState::STATUS_STARTED;
+		$this->run_state->write_manifest( $manifest );
+
 		// In case custom taxonomies were explicitly provided, but category/post_tag/author were not among those, warn the user that they won't be migrated and ask for confirmation to continue.
 		if ( isset( $assoc_args['custom-taxonomies-csv'] ) ) {
 			if ( ! in_array( 'category', $taxonomies_to_migrate ) ) {
@@ -661,14 +719,7 @@ class ContentDiffMigrator {
 		$this->cmd_list_migrated_source_hostnames( [], [] );
 		$this->warn_if_similar_hostname_exists( $source_hostname );
 
-		// Read post_types from manifest (saved by search command).
-		$manifest = $this->run_state->get_manifest();
-		if ( is_null( $manifest ) ) {
-			throw new \RuntimeException( sprintf( 'Can not find manifest file (%s).', RunState::FILE_MANIFEST ) ); // phpcs:ignore -- exception message is for internal logging/debugging WordPress.Security.EscapeOutput.ExceptionNotEscaped.
-		}
-
 		// Get all taxonomies which exist in Live DB.
-		// Prepare and validate table name.
 		$table_live_term_taxonomy = $live_table_prefix . 'term_taxonomy';
 		DB::validate_table_name( $table_live_term_taxonomy );
 		$live_taxonomies = $wpdb->get_col( "SELECT DISTINCT( taxonomy ) FROM {$table_live_term_taxonomy} ;" ); // phpcs:ignore -- table name was properly validated.
@@ -818,6 +869,12 @@ class ContentDiffMigrator {
 		if ( ! empty( $summary['users']['merged'] ) ) {
 			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::INFO, sprintf( '- total merged users: %s', number_format( $summary['users']['merged'] ) ) );
 		}
+
+		// Mark migrate as completed and record taxonomies.
+		$manifest                   = $this->run_state->get_manifest() ?? [];
+		$manifest['taxonomies']     = $taxonomies_to_migrate;
+		$manifest['migrate_status'] = RunState::STATUS_COMPLETED;
+		$this->run_state->write_manifest( $manifest );
 
 		Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( 'All done migrating content from %s! 🙌 ', $source_hostname ) );
 		wp_cache_flush();

--- a/src/Logic/RunState.php
+++ b/src/Logic/RunState.php
@@ -9,6 +9,8 @@ namespace Newspack\ContentDiffMigrator\Logic;
 
 use Newspack\ContentDiffMigrator\Utils\Logger;
 use Psr\Log\LogLevel;
+use RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
 
 /**
  * RunState keeps track of IDs/objects which need to be migrated, and progress of the migration.
@@ -16,6 +18,10 @@ use Psr\Log\LogLevel;
  * This data is persisted in JSON/JSONL files in the $run_state_dir path.
  */
 class RunState {
+
+	// Status constants.
+	public const STATUS_STARTED   = 'started';
+	public const STATUS_COMPLETED = 'completed';
 
 	// Run-state filenames.
 	public const FILE_MANIFEST             = 'manifest.json';
@@ -69,6 +75,91 @@ class RunState {
 	 */
 	public function get_manifest(): ?array {
 		return $this->read_json( self::FILE_MANIFEST );
+	}
+
+	/**
+	 * Deletes the entire run-state directory and recreates it as empty.
+	 *
+	 * @return void
+	 */
+	public function delete_run_state(): void {
+		if ( ! is_dir( $this->run_state_dir ) ) {
+			return;
+		}
+
+		$files = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $this->run_state_dir, RecursiveDirectoryIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+
+		foreach ( $files as $file ) {
+			$path = $file->getRealPath();
+			if ( false === $path ) {
+				continue;
+			}
+			$file->isDir() ? rmdir( $path ) : unlink( $path ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.directory_rmdir.
+		}
+
+		rmdir( $this->run_state_dir ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.directory_rmdir.
+
+		// Recreate empty directory for fresh start.
+		wp_mkdir_p( $this->run_state_dir );
+	}
+
+	/**
+	 * Updates the search_status field in the manifest.
+	 *
+	 * @param string $status Status value (use STATUS_STARTED or STATUS_COMPLETED constants).
+	 *
+	 * @return bool Success.
+	 *
+	 * @throws \InvalidArgumentException If status is not a valid value.
+	 */
+	public function update_search_status( string $status ): bool {
+		if ( self::STATUS_STARTED !== $status && self::STATUS_COMPLETED !== $status ) {
+			throw new \InvalidArgumentException( sprintf( 'Invalid status: %s', $status ) ); // phpcs:ignore -- exception message is for internal logging/debugging WordPress.Security.EscapeOutput.ExceptionNotEscaped.
+		}
+		$manifest                  = $this->get_manifest() ?? [];
+		$manifest['search_status'] = $status;
+		return $this->write_manifest( $manifest );
+	}
+
+	/**
+	 * Updates the migrate_status field in the manifest.
+	 *
+	 * @param string $status Status value (use STATUS_STARTED or STATUS_COMPLETED constants).
+	 *
+	 * @return bool Success.
+	 *
+	 * @throws \InvalidArgumentException If status is not a valid value.
+	 */
+	public function update_migrate_status( string $status ): bool {
+		if ( self::STATUS_STARTED !== $status && self::STATUS_COMPLETED !== $status ) {
+			throw new \InvalidArgumentException( sprintf( 'Invalid status: %s', $status ) ); // phpcs:ignore -- exception message is for internal logging/debugging WordPress.Security.EscapeOutput.ExceptionNotEscaped.
+		}
+		$manifest                   = $this->get_manifest() ?? [];
+		$manifest['migrate_status'] = $status;
+		return $this->write_manifest( $manifest );
+	}
+
+	/**
+	 * Gets the search_status from the manifest.
+	 *
+	 * @return string|null Status value, or null if not set.
+	 */
+	public function get_search_status(): ?string {
+		$manifest = $this->get_manifest();
+		return $manifest['search_status'] ?? null;
+	}
+
+	/**
+	 * Gets the migrate_status from the manifest.
+	 *
+	 * @return string|null Status value, or null if not set.
+	 */
+	public function get_migrate_status(): ?string {
+		$manifest = $this->get_manifest();
+		return $manifest['migrate_status'] ?? null;
 	}
 
 	/**

--- a/tests/unit/Logic/RunStateTest.php
+++ b/tests/unit/Logic/RunStateTest.php
@@ -899,4 +899,250 @@ class RunStateTest extends WP_UnitTestCase {
 
 		$this->assertEquals( $manifest, $result );
 	}
+
+	// =========================================================================
+	// STATUS HELPER TESTS
+	// =========================================================================
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::update_search_status
+	 */
+	public function test_update_search_status_should_set_started_status(): void {
+		$result = $this->run_state->update_search_status( RunState::STATUS_STARTED );
+
+		$this->assertTrue( $result );
+		$manifest = $this->run_state->get_manifest();
+		$this->assertEquals( RunState::STATUS_STARTED, $manifest['search_status'] );
+	}
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::update_search_status
+	 */
+	public function test_update_search_status_should_set_completed_status(): void {
+		$result = $this->run_state->update_search_status( RunState::STATUS_COMPLETED );
+
+		$this->assertTrue( $result );
+		$manifest = $this->run_state->get_manifest();
+		$this->assertEquals( RunState::STATUS_COMPLETED, $manifest['search_status'] );
+	}
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::update_search_status
+	 */
+	public function test_update_search_status_should_throw_exception_for_invalid_status(): void {
+		$this->expectException( \InvalidArgumentException::class );
+
+		$this->run_state->update_search_status( 'invalid_status' );
+	}
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::update_migrate_status
+	 */
+	public function test_update_migrate_status_should_set_started_status(): void {
+		$result = $this->run_state->update_migrate_status( RunState::STATUS_STARTED );
+
+		$this->assertTrue( $result );
+		$manifest = $this->run_state->get_manifest();
+		$this->assertEquals( RunState::STATUS_STARTED, $manifest['migrate_status'] );
+	}
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::update_migrate_status
+	 */
+	public function test_update_migrate_status_should_set_completed_status(): void {
+		$result = $this->run_state->update_migrate_status( RunState::STATUS_COMPLETED );
+
+		$this->assertTrue( $result );
+		$manifest = $this->run_state->get_manifest();
+		$this->assertEquals( RunState::STATUS_COMPLETED, $manifest['migrate_status'] );
+	}
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::update_migrate_status
+	 */
+	public function test_update_migrate_status_should_throw_exception_for_invalid_status(): void {
+		$this->expectException( \InvalidArgumentException::class );
+
+		$this->run_state->update_migrate_status( 'invalid_status' );
+	}
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::get_search_status
+	 */
+	public function test_get_search_status_should_return_null_when_not_set(): void {
+		$result = $this->run_state->get_search_status();
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::get_search_status
+	 */
+	public function test_get_search_status_should_return_status_when_set(): void {
+		$this->run_state->update_search_status( RunState::STATUS_COMPLETED );
+
+		$result = $this->run_state->get_search_status();
+
+		$this->assertEquals( RunState::STATUS_COMPLETED, $result );
+	}
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::get_migrate_status
+	 */
+	public function test_get_migrate_status_should_return_null_when_not_set(): void {
+		$result = $this->run_state->get_migrate_status();
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::get_migrate_status
+	 */
+	public function test_get_migrate_status_should_return_status_when_set(): void {
+		$this->run_state->update_migrate_status( RunState::STATUS_COMPLETED );
+
+		$result = $this->run_state->get_migrate_status();
+
+		$this->assertEquals( RunState::STATUS_COMPLETED, $result );
+	}
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::update_search_status
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::update_migrate_status
+	 */
+	public function test_status_updates_should_preserve_existing_manifest_data(): void {
+		// Write initial manifest data.
+		$this->run_state->write_manifest(
+			[
+				'created_at'        => '2024-01-01 12:00:00',
+				'source_hostname'   => 'example.com',
+				'live_table_prefix' => 'live_',
+			]
+		);
+
+		// Update statuses.
+		$this->run_state->update_search_status( RunState::STATUS_COMPLETED );
+		$this->run_state->update_migrate_status( RunState::STATUS_STARTED );
+
+		// Verify original data is preserved.
+		$manifest = $this->run_state->get_manifest();
+		$this->assertEquals( '2024-01-01 12:00:00', $manifest['created_at'] );
+		$this->assertEquals( 'example.com', $manifest['source_hostname'] );
+		$this->assertEquals( 'live_', $manifest['live_table_prefix'] );
+		$this->assertEquals( RunState::STATUS_COMPLETED, $manifest['search_status'] );
+		$this->assertEquals( RunState::STATUS_STARTED, $manifest['migrate_status'] );
+	}
+
+	// =========================================================================
+	// DELETE RUN-STATE TESTS
+	// =========================================================================
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::delete_run_state
+	 */
+	public function test_delete_run_state_should_remove_all_files(): void {
+		// Create some run-state files.
+		$this->run_state->write_manifest( [ 'test' => 'data' ] );
+		$this->run_state->write_new_ids( [ 1, 2, 3 ] );
+		$this->run_state->append_imported_post(
+			[
+				'post_type' => 'post',
+				'id_old'    => 1,
+				'id_new'    => 10,
+			]
+		);
+
+		// Verify files exist.
+		$this->assertFileExists( $this->temp_dir . '/run-state/' . RunState::FILE_MANIFEST );
+		$this->assertFileExists( $this->temp_dir . '/run-state/' . RunState::FILE_NEW_IDS );
+		$this->assertFileExists( $this->temp_dir . '/run-state/' . RunState::FILE_IMPORTED_POSTS );
+
+		// Delete run-state.
+		$this->run_state->delete_run_state();
+
+		// Verify files are deleted but directory still exists (recreated empty).
+		$this->assertDirectoryExists( $this->temp_dir . '/run-state' );
+		$this->assertFileDoesNotExist( $this->temp_dir . '/run-state/' . RunState::FILE_MANIFEST );
+		$this->assertFileDoesNotExist( $this->temp_dir . '/run-state/' . RunState::FILE_NEW_IDS );
+		$this->assertFileDoesNotExist( $this->temp_dir . '/run-state/' . RunState::FILE_IMPORTED_POSTS );
+	}
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::delete_run_state
+	 */
+	public function test_delete_run_state_should_handle_nonexistent_directory(): void {
+		// Create RunState with a directory that doesn't exist.
+		$nonexistent_dir = $this->temp_dir . '/nonexistent/run-state';
+
+		// Remove the directory if it was auto-created.
+		if ( is_dir( $nonexistent_dir ) ) {
+			rmdir( $nonexistent_dir ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.directory_rmdir.
+		}
+		if ( is_dir( dirname( $nonexistent_dir ) ) ) {
+			rmdir( dirname( $nonexistent_dir ) ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.directory_rmdir.
+		}
+
+		// Create new RunState which creates the directory.
+		$run_state = new RunState( $nonexistent_dir );
+		// Remove it again for testing.
+		rmdir( $nonexistent_dir ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.directory_rmdir.
+
+		// Should not throw exception for nonexistent directory.
+		$run_state->delete_run_state();
+
+		$this->assertTrue( true ); // If we got here without exception, test passed.
+	}
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::delete_run_state
+	 */
+	public function test_delete_run_state_should_handle_nested_directories(): void {
+		// Create a nested directory structure within run-state.
+		$nested_dir = $this->temp_dir . '/run-state/nested/deep';
+		wp_mkdir_p( $nested_dir );
+		file_put_contents( $nested_dir . '/file.txt', 'test content' );
+		file_put_contents( $this->temp_dir . '/run-state/nested/another.txt', 'more content' );
+
+		// Delete run-state.
+		$this->run_state->delete_run_state();
+
+		// Verify all nested content is deleted.
+		$this->assertDirectoryExists( $this->temp_dir . '/run-state' );
+		$this->assertDirectoryDoesNotExist( $nested_dir );
+		$this->assertDirectoryDoesNotExist( $this->temp_dir . '/run-state/nested' );
+	}
+
+	/**
+	 * @test
+	 * @covers \Newspack\ContentDiffMigrator\Logic\RunState::delete_run_state
+	 */
+	public function test_delete_run_state_should_allow_fresh_start(): void {
+		// Create initial data.
+		$this->run_state->write_manifest( [ 'old' => 'data' ] );
+
+		// Delete and start fresh.
+		$this->run_state->delete_run_state();
+
+		// Write new data.
+		$this->run_state->write_manifest( [ 'new' => 'data' ] );
+
+		// Verify new data is written correctly.
+		$manifest = $this->run_state->get_manifest();
+		$this->assertEquals( [ 'new' => 'data' ], $manifest );
+		$this->assertArrayNotHasKey( 'old', $manifest );
+	}
 }


### PR DESCRIPTION
This PR is considered as an immediate extension of v.2 before creating the actual v.2 release, and it is merged to trunk together with the [PR#9](https://github.com/Automattic/newspack-content-diff-migrator/pull/9).

---

While updating Knife to use CDiff v.2 I noted that v.2's `search` command was not made properly auto-resumable, in case the command (ssh session) would get interrupted. v.1 had this bit different, with somewhat less security, while v.2's `search` command was checking the integrity of `--data-dir` and RunState, and not allowing a re-run if command got interrupted.

Added in this PR:
- several extra fields to `manifest.json`, including `search_status`, `migrate_status`, and additionally and purely for convenience also added `taxonomies` being migrated similarly how the list of CPTs migrated was already written in `manifest.json`
- when/if the `search` command re-runs, it still checks if `--data-dir`/RunState exists, but it now doesn't exit automatically if it does exist; it checks the `search_status` and allows a re-run if it is not "completed", and at the beginning of this re-run it flushes the `run-state`/`--data-dir` and deletes all the JSONs from it for security, to prevent potential collision with any existing files (shouldn't happen, but flushing is an elegant and secure way to re-start the `search` command)
- added some more tests

- [x] confirmed that PHPCS has been run
