### PR TITLE
Memory optimizations, batch processing in search command

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -55,12 +55,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/newspack-migration-tools.git",
-                "reference": "2c17b0df3df5dcc66bc89f90fa4a3a79d9f77de3"
+                "reference": "73e5bcb6fe4ccdec069084148fd9fd6da70a3cc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/newspack-migration-tools/zipball/2c17b0df3df5dcc66bc89f90fa4a3a79d9f77de3",
-                "reference": "2c17b0df3df5dcc66bc89f90fa4a3a79d9f77de3",
+                "url": "https://api.github.com/repos/Automattic/newspack-migration-tools/zipball/73e5bcb6fe4ccdec069084148fd9fd6da70a3cc4",
+                "reference": "73e5bcb6fe4ccdec069084148fd9fd6da70a3cc4",
                 "shasum": ""
             },
             "require": {
@@ -119,7 +119,7 @@
                 "source": "https://github.com/Automattic/newspack-migration-tools/tree/trunk",
                 "issues": "https://github.com/Automattic/newspack-migration-tools/issues"
             },
-            "time": "2026-03-11T17:38:35+00:00"
+            "time": "2026-03-31T09:46:00+00:00"
         },
         {
             "name": "bramus/ansi-php",

--- a/newspack-content-diff-migrator.php
+++ b/newspack-content-diff-migrator.php
@@ -5,7 +5,7 @@
  * Plugin URI:  https://newspack.com
  * Author:      Automattic
  * Author URI:  https://newspack.com
- * Version:     2.0.0
+ * Version:     2.1.0
  *
  * @package  Newspack_Content_Diff_Migrator
  */

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -564,16 +564,31 @@ class ContentDiffMigrator {
 			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( '%d modified IDs found (see %s).', count( $modified_live_ids ), rtrim( $data_dir, '/' ) . '/run-state/' . RunState::FILE_MODIFIED_IDS ) );
 			MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
 
-			// Query live DB for attachments.
+			// Query live DB for attachments in batches.
 			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, 'Searching live DB for attachments ...' );
-			$results_live_attachments = $this->logic->get_posts_rows_for_content_diff( $live_table_prefix . 'posts', [ 'attachment' ], [ 'inherit' ] );
-			MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
-
-			// Check new attachments.
-			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( 'Fetched %s total from live site, checking for new ones...', count( $results_live_attachments ) ) );
-			$new_live_attachment_ids = $this->logic->filter_new_live_ids( $results_live_attachments, $attachment_old_id_map );
-			$new_live_ids            = array_merge( $new_live_ids, $new_live_attachment_ids );
+			$batch_size              = 20000;
+			$total_live_attachments  = $this->logic->count_posts_for_content_diff( $live_table_prefix . 'posts', [ 'attachment' ], [ 'inherit' ] );
+			$new_live_attachment_ids = [];
+			$total_batches           = (int) ceil( $total_live_attachments / $batch_size );
+			$current_batch           = 0;
+			for ( $offset = 0; $offset < $total_live_attachments; $offset += $batch_size ) {
+				++$current_batch;
+				$live_batch = $this->logic->get_posts_rows_for_content_diff( $live_table_prefix . 'posts', [ 'attachment' ], [ 'inherit' ], $batch_size, $offset );
+				Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, sprintf( 'Batch %d/%d...', $current_batch, $total_batches ) );
+				// More verbose log for action/debug log file.
+				Logger::instance()->log(
+					Logger::OUTPUT_FILE,
+					LogLevel::DEBUG,
+					sprintf( 'Processing live attachments batch: offset=%d, limit=%d, total=%d, fetched=%d', $offset, $batch_size, $total_live_attachments, count( $live_batch ) )
+				);
+				$new_ids_batch           = $this->logic->filter_new_live_ids( $live_batch, $attachment_old_id_map );
+				$new_live_attachment_ids = array_merge( $new_live_attachment_ids, $new_ids_batch );
+				unset( $live_batch, $new_ids_batch );
+				MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
+			}
+			$new_live_ids = array_merge( $new_live_ids, $new_live_attachment_ids );
 			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( '%d new attachment IDs found (see %s).', count( $new_live_attachment_ids ), rtrim( $data_dir, '/' ) . '/run-state/' . RunState::FILE_NEW_IDS ) );
+			unset( $new_live_attachment_ids );
 
 		} catch ( \Exception $e ) {
 			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::ERROR, $e->getMessage() );
@@ -1767,96 +1782,147 @@ class ContentDiffMigrator {
 		$terms_attributed_count       = 0;
 
 		/**
-		 * Match and attribute non-attachments post_types.
+		 * Match and attribute non-attachments post_types in batches, for memory performance with large datasets.
 		 */
 		$post_types_non_attachments = array_filter( $post_types, fn( $post_type ) => 'attachment' !== $post_type );
 		if ( ! empty( $post_types_non_attachments ) ) {
 			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( 'Attributing %s types...', implode( ',', $post_types_non_attachments ) ) );
-			$results_local_posts = $this->logic->get_posts_rows_for_content_diff( $wpdb->prefix . 'posts', $post_types_non_attachments, $statuses_regular );
-			$results_live_posts  = $this->logic->get_posts_rows_for_content_diff( $live_table_prefix . 'posts', $post_types_non_attachments, $statuses_regular );
-			MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
-			$matched_posts = $this->logic->match_local_to_live_posts( $results_local_posts, $results_live_posts );
-			MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
 
-			// Fetch post types.
-			$post_types_map = [];
-			if ( ! empty( $matched_posts ) ) {
-				$local_ids        = array_column( $matched_posts, 'local_id' );
-				$ids_placeholders = implode( ',', array_fill( 0, count( $local_ids ), '%d' ) );
-				// phpcs:disable -- WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare.
-				$post_types_results = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_type FROM {$wpdb->posts} WHERE ID IN ( {$ids_placeholders} )", $local_ids ), ARRAY_A );
-				// phpcs:enable
-				$post_types_map = array_column( $post_types_results, 'post_type', 'ID' );
-			}
+			// Build live lookup once from all live posts.
+			$results_live_posts = $this->logic->get_posts_rows_for_content_diff( $live_table_prefix . 'posts', $post_types_non_attachments, $statuses_regular );
+			$live_posts_lookup  = null;
+			// Populate $live_posts_lookup (passed by reference) with the live posts.
+			$this->logic->match_local_to_live_posts( [], $results_live_posts, $live_posts_lookup );
+			unset( $results_live_posts );
+			MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
 
 			// Get posts that are truly unattributed (no meta from ANY source).
 			$unattributed_posts     = $this->logic->get_unattributed_post_ids( $post_types_non_attachments );
 			$unattributed_posts_map = array_flip( array_column( $unattributed_posts, 'ID' ) );
+			unset( $unattributed_posts );
 			MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
 
-			// Do the actual attribution and set the metas.
-			foreach ( $matched_posts as $key_match => $match ) {
-				// Skip if post doesn't exist in DB.
-				if ( ! isset( $post_types_map[ $match['local_id'] ] ) ) {
-					Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::WARNING, sprintf( 'Post ID %d not found in database, skipping attribution.', $match['local_id'] ) );
-					continue;
-				}
-				// Skip if already attributed to ANY source.
-				if ( ! isset( $unattributed_posts_map[ $match['local_id'] ] ) ) {
-					continue;
-				}
-				// Attribute post.
-				update_post_meta( $match['local_id'], $meta_key, $match['live_id'] );
-				MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1, $key_match, 1000 );
+			// Process local posts in batches, reusing the live lookup.
+			$batch_size    = 20000;
+			$total_local   = $this->logic->count_posts_for_content_diff( $wpdb->prefix . 'posts', $post_types_non_attachments, $statuses_regular );
+			$total_batches = (int) ceil( $total_local / $batch_size );
+			$current_batch = 0;
+			for ( $offset = 0; $offset < $total_local; $offset += $batch_size ) {
+				++$current_batch;
+				$local_batch   = $this->logic->get_posts_rows_for_content_diff( $wpdb->prefix . 'posts', $post_types_non_attachments, $statuses_regular, $batch_size, $offset );
+				$matched_batch = $this->logic->match_local_to_live_posts( $local_batch, [], $live_posts_lookup );
+				Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, sprintf( 'Batch %d/%d...', $current_batch, $total_batches ) );
+				// More verbose log for action/debug log file.
 				Logger::instance()->log(
 					Logger::OUTPUT_FILE,
 					LogLevel::DEBUG,
-					sprintf( 'Post attributed to %s', $source_hostname ),
-					[
-						'local_id' => $match['local_id'],
-						'live_id'  => $match['live_id'],
-					] 
+					sprintf( 'Processing posts batch: offset=%d, limit=%d, total=%d, fetched=%d, matched=%d', $offset, $batch_size, $total_local, count( $local_batch ), count( $matched_batch ) )
 				);
-				++$posts_attributed_count;
+				unset( $local_batch );
+
+				// Per-batch existence check: verify matched IDs exist in DB.
+				$existing_ids_map = [];
+				if ( ! empty( $matched_batch ) ) {
+					$local_ids        = array_column( $matched_batch, 'local_id' );
+					$ids_placeholders = implode( ',', array_fill( 0, count( $local_ids ), '%d' ) );
+					// phpcs:disable -- WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare.
+					$existing_results = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE ID IN ( {$ids_placeholders} )", $local_ids ) );
+					// phpcs:enable
+					$existing_ids_map = array_flip( array_map( 'intval', $existing_results ) );
+				}
+
+				foreach ( $matched_batch as $key_match => $match ) {
+					// Skip if post doesn't exist in DB.
+					if ( ! isset( $existing_ids_map[ $match['local_id'] ] ) ) {
+						Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::WARNING, sprintf( 'Post ID %d not found in database, skipping attribution.', $match['local_id'] ) );
+						continue;
+					}
+					// Skip if already attributed to ANY source.
+					if ( ! isset( $unattributed_posts_map[ $match['local_id'] ] ) ) {
+						continue;
+					}
+					// Attribute post.
+					update_post_meta( $match['local_id'], $meta_key, $match['live_id'] );
+					MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1, $key_match, 1000 );
+					Logger::instance()->log(
+						Logger::OUTPUT_FILE,
+						LogLevel::DEBUG,
+						sprintf( 'Post attributed to %s', $source_hostname ),
+						[
+							'local_id' => $match['local_id'],
+							'live_id'  => $match['live_id'],
+						]
+					);
+					++$posts_attributed_count;
+				}
+
+				unset( $matched_batch, $existing_ids_map );
+				MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
 			}
+			unset( $live_posts_lookup, $unattributed_posts_map );
 			MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
 		}
 
 		/**
-		 * Match and attribute attachments.
+		 * Match and attribute attachments in batches, for memory performance with large datasets.
 		 */
 		Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, 'Attributing attachments...' );
-		$results_local_attachments = $this->logic->get_posts_rows_for_content_diff( $wpdb->prefix . 'posts', [ 'attachment' ], $statuses_attachment );
-		$results_live_attachments  = $this->logic->get_posts_rows_for_content_diff( $live_table_prefix . 'posts', [ 'attachment' ], $statuses_attachment );
-		MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
-		$matched_attachments = $this->logic->match_local_to_live_posts( $results_local_attachments, $results_live_attachments );
+
+		// Build live lookup once from all live attachments.
+		$results_live_attachments = $this->logic->get_posts_rows_for_content_diff( $live_table_prefix . 'posts', [ 'attachment' ], $statuses_attachment );
+		$live_attachment_lookup   = null;
+		// Populate $live_attachment_lookup (passed by reference) with the live attachments.
+		$this->logic->match_local_to_live_posts( [], $results_live_attachments, $live_attachment_lookup );
+		unset( $results_live_attachments );
 		MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
 
 		// Get attachments that are truly unattributed (no meta from ANY source).
 		$unattributed_attachments     = $this->logic->get_unattributed_attachment_ids();
 		$unattributed_attachments_map = array_flip( $unattributed_attachments );
+		unset( $unattributed_attachments );
 		MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
 
-		// Do the actual attribution and set the metas.
-		foreach ( $matched_attachments as $key_match => $match ) {
-			// Skip if already attributed to ANY source.
-			if ( ! isset( $unattributed_attachments_map[ $match['local_id'] ] ) ) {
-				continue;
-			}
-			// Attribute attachment.
-			update_post_meta( $match['local_id'], $meta_key, $match['live_id'] );
-			MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1, $key_match, 1000 );
+		// Process local attachments in batches, reusing the live lookup.
+		$batch_size    = 20000;
+		$total_local   = $this->logic->count_posts_for_content_diff( $wpdb->prefix . 'posts', [ 'attachment' ], $statuses_attachment );
+		$total_batches = (int) ceil( $total_local / $batch_size );
+		$current_batch = 0;
+		for ( $offset = 0; $offset < $total_local; $offset += $batch_size ) {
+			++$current_batch;
+			$local_batch   = $this->logic->get_posts_rows_for_content_diff( $wpdb->prefix . 'posts', [ 'attachment' ], $statuses_attachment, $batch_size, $offset );
+			$matched_batch = $this->logic->match_local_to_live_posts( $local_batch, [], $live_attachment_lookup );
+			Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, sprintf( 'Batch %d/%d...', $current_batch, $total_batches ) );
+			// More verbose log for action/debug log file.
 			Logger::instance()->log(
 				Logger::OUTPUT_FILE,
 				LogLevel::DEBUG,
-				sprintf( 'Attachment attributed to %s', $source_hostname ),
-				[
-					'local_id' => $match['local_id'],
-					'live_id'  => $match['live_id'],
-				] 
+				sprintf( 'Processing attachments batch: offset=%d, limit=%d, total=%d, fetched=%d, matched=%d', $offset, $batch_size, $total_local, count( $local_batch ), count( $matched_batch ) )
 			);
-			++$attachments_attributed_count;
+			unset( $local_batch );
+
+			foreach ( $matched_batch as $key_match => $match ) {
+				// Skip if already attributed to ANY source.
+				if ( ! isset( $unattributed_attachments_map[ $match['local_id'] ] ) ) {
+					continue;
+				}
+				update_post_meta( $match['local_id'], $meta_key, $match['live_id'] );
+				MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1, $key_match, 1000 );
+				Logger::instance()->log(
+					Logger::OUTPUT_FILE,
+					LogLevel::DEBUG,
+					sprintf( 'Attachment attributed to %s', $source_hostname ),
+					[
+						'local_id' => $match['local_id'],
+						'live_id'  => $match['live_id'],
+					]
+				);
+				++$attachments_attributed_count;
+			}
+
+			unset( $matched_batch );
+			MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
 		}
+		unset( $live_attachment_lookup, $unattributed_attachments_map );
 		MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
 
 		/**

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -1456,6 +1456,7 @@ class ContentDiffMigrator {
 					$existing_local_id
 				);
 				$imported_posts_data[] = $result;
+				MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1, $key_live_id, 1000 );
 
 				// Append post to run-state for resume capability and reports.
 				$status = null !== $existing_local_id ? 'modified' : 'imported';

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -786,9 +786,13 @@ class ContentDiffMigrator {
 			// Get modified IDs which were already deleted, and skip them.
 			$already_deleted_modified_ids_map = $this->run_state->get_deleted_modified_ids_map();
 			$local_ids_to_delete              = array_values( array_diff( array_values( $modified_ids_map ), array_values( $already_deleted_modified_ids_map ) ) );
+			$already_deleted_count            = count( $already_deleted_modified_ids_map );
+			if ( $already_deleted_count > 0 ) {
+				Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( '%d posts were already deleted, continuing from there...', $already_deleted_count ) );
+			}
 			
 			// Delete modified posts so they can be re-imported.
-			foreach ( $local_ids_to_delete as $id ) {
+			foreach ( $local_ids_to_delete as $key_delete => $id ) {
 				$deleted = wp_delete_post( $id, true );
 				if ( false === $deleted || null === $deleted ) {
 					$context = [
@@ -799,6 +803,7 @@ class ContentDiffMigrator {
 					// Don't continue and save to run-state if deletion failed.
 					continue;
 				}
+				MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1, $key_delete, 300 );
 
 				// Save run-state info that this modified ID was deleted.
 				$this->run_state->append_deleted_modified_id(

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -760,6 +760,11 @@ class ContentDiffMigrator {
 			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( 'Other Taxonomies found in live DB which will not be migrated: %s', implode( ', ', $unmigrated_taxonomies ) ) );
 		}
 
+		// Register taxonomies (before deletion and reimport of modified, so wp_delete_post() properly cleans up term relationships).
+		foreach ( $taxonomies_to_migrate as $taxonomy_name ) {
+			$this->data_importer->ensure_taxonomy_registered( $taxonomy_name );
+		}
+
 		// Migrate all WP_Users (for WooComm data).
 		Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, 'Migrating all WP_Users...' );
 		$inserted_wp_users_updates = $this->logic->migrate_all_users( $live_table_prefix, $source_hostname );

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -39,6 +39,13 @@ class ContentDiffMigrator {
 	const DEFAULT_TAXONOMIES = [ 'category', 'post_tag', 'author', 'brand' ];
 
 	/**
+	 * Number of post objects processed in a batch which is memory-safe for large datasets.
+	 *
+	 * @var int
+	 */
+	const MEMORY_SAFE_BATCH_SIZE = 20000;
+
+	/**
 	 * Content Diff logic class.
 	 *
 	 * @var ContentDiffLogic Logic.
@@ -566,7 +573,7 @@ class ContentDiffMigrator {
 
 			// Query live DB for attachments in batches.
 			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, 'Searching live DB for attachments ...' );
-			$batch_size              = 20000;
+			$batch_size              = self::MEMORY_SAFE_BATCH_SIZE;
 			$total_live_attachments  = $this->logic->count_posts_for_content_diff( $live_table_prefix . 'posts', [ 'attachment' ], [ 'inherit' ] );
 			$new_live_attachment_ids = [];
 			$total_batches           = (int) ceil( $total_live_attachments / $batch_size );
@@ -1803,7 +1810,7 @@ class ContentDiffMigrator {
 			MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
 
 			// Process local posts in batches, reusing the live lookup.
-			$batch_size    = 20000;
+			$batch_size    = self::MEMORY_SAFE_BATCH_SIZE;
 			$total_local   = $this->logic->count_posts_for_content_diff( $wpdb->prefix . 'posts', $post_types_non_attachments, $statuses_regular );
 			$total_batches = (int) ceil( $total_local / $batch_size );
 			$current_batch = 0;
@@ -1883,7 +1890,7 @@ class ContentDiffMigrator {
 		MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
 
 		// Process local attachments in batches, reusing the live lookup.
-		$batch_size    = 20000;
+		$batch_size    = self::MEMORY_SAFE_BATCH_SIZE;
 		$total_local   = $this->logic->count_posts_for_content_diff( $wpdb->prefix . 'posts', [ 'attachment' ], $statuses_attachment );
 		$total_batches = (int) ceil( $total_local / $batch_size );
 		$current_batch = 0;

--- a/src/Logic/ContentDiffLogic.php
+++ b/src/Logic/ContentDiffLogic.php
@@ -1290,6 +1290,8 @@ class ContentDiffLogic {
 				// Append modified user (avatar-only update) to run-state for reports.
 				$this->data_importer->append_user( (int) $live_id, (int) $local_id, 'modified' );
 			}
+
+			MemoryCleanupHook::cleanup( 0, $checked, 1000 );
 		}
 
 		return [
@@ -1390,6 +1392,8 @@ class ContentDiffLogic {
 				// Append modified attachment to run-state for reports.
 				$this->data_importer->append_post( (int) $live_id, (int) $local_id, 'attachment', 'modified' );
 			}
+
+			MemoryCleanupHook::cleanup( 0, $checked, 1000 );
 		}
 
 		return [
@@ -1500,6 +1504,8 @@ class ContentDiffLogic {
 				// Append modified term to run-state for reports.
 				$this->data_importer->append_term( (int) $live_id, (int) $local_id, $local_term->taxonomy, 'modified' );
 			}
+
+			MemoryCleanupHook::cleanup( 0, $checked, 1000 );
 		}
 
 		return [

--- a/src/Logic/ContentDiffLogic.php
+++ b/src/Logic/ContentDiffLogic.php
@@ -12,6 +12,7 @@ use Newspack\ContentDiffMigrator\Utils\DB;
 use Newspack\ContentDiffMigrator\Utils\Logger;
 use Newspack\ContentDiffMigrator\Utils\Progress;
 use Newspack\ContentDiffMigrator\Utils\SLAHelper;
+use Newspack\MigrationTools\Hooks\MemoryCleanupHook;
 use Psr\Log\LogLevel;
 use RuntimeException;
 use WP_User;
@@ -828,6 +829,9 @@ class ContentDiffLogic {
 			if ( $progress_milestone ) {
 				Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, Progress::format( $progress_milestone ) );
 			}
+
+			// Periodic memory cleanup to prevent OOM from accumulated DB queries.
+			MemoryCleanupHook::cleanup( 0, $key_live_post, 1000 );
 
 			$live_id = (int) $live_post['ID'];
 

--- a/src/Logic/ContentDiffLogic.php
+++ b/src/Logic/ContentDiffLogic.php
@@ -171,13 +171,15 @@ class ContentDiffLogic {
 	 * Gets records from the $posts_table, $post_types, returns the minimal set of columns needed to determine whether a post
 	 * doesn't exist in DB and needs to be inserted, or has been modified and needs to be updated.
 	 *
-	 * @param string $posts_table   Name of posts table.
-	 * @param array  $post_types    Post types to fetch.
-	 * @param array  $post_statuses Post statuses to fetch.
+	 * @param string   $posts_table   Name of posts table.
+	 * @param array    $post_types    Post types to fetch.
+	 * @param array    $post_statuses Post statuses to fetch.
+	 * @param int|null $limit         Optional limit for batching. If null, returns all results.
+	 * @param int|null $offset        Optional offset for batching. Only used when $limit is set. Defaults to 0.
 	 *
 	 * @return array Associative array with columns specified in used query.
 	 */
-	public function get_posts_rows_for_content_diff( string $posts_table, array $post_types, array $post_statuses ): array {
+	public function get_posts_rows_for_content_diff( string $posts_table, array $post_types, array $post_statuses, ?int $limit = null, ?int $offset = null ): array {
 		// Validate table name.
 		DB::validate_table_name( $posts_table );
 		
@@ -187,13 +189,16 @@ class ContentDiffLogic {
 		$post_statuses_placeholders     = array_fill( 0, count( $post_statuses ), '%s' );
 		$post_statuses_placeholders_csv = implode( ',', $post_statuses_placeholders );
 
+		// Build limit clause for batching, which also requires ORDER BY for consistent results.
+		$limit_clause = null !== $limit ? ' ORDER BY ID ASC LIMIT ' . ( $offset ?? 0 ) . ", {$limit}" : '';
+
 		// $wpdb->prepare can't handle table names, so we'll additionally str_replace {TABLE}.
-		// phpcs:disable
+		// phpcs:disable -- table name was properly validated WordPress.DB.PreparedSQL.InterpolatedNotPrepared.
 		$sql_replace_table = $this->wpdb->prepare(
 			"SELECT ID, post_author, post_name, post_title, post_status, post_type, post_date, post_modified, comment_count
 				FROM {TABLE}
 				WHERE post_type IN ( $post_types_placeholders_csv )
-				AND post_status IN ( $post_statuses_placeholders_csv );",
+				AND post_status IN ( $post_statuses_placeholders_csv ){$limit_clause};",
 			array_merge( $post_types, $post_statuses )
 		);
 		$results = $this->wpdb->get_results( str_replace( '{TABLE}', $posts_table, $sql_replace_table ), ARRAY_A );
@@ -203,6 +208,36 @@ class ContentDiffLogic {
 		$results = is_null( $results ) ? [] : $results;
 
 		return $results;
+	}
+
+	/**
+	 * Counts posts matching the given criteria. Used with batched get_posts_rows_for_content_diff().
+	 *
+	 * @param string $posts_table   Name of posts table.
+	 * @param array  $post_types    Post types to count.
+	 * @param array  $post_statuses Post statuses to count.
+	 *
+	 * @return int Count of matching posts.
+	 */
+	public function count_posts_for_content_diff( string $posts_table, array $post_types, array $post_statuses ): int {
+		DB::validate_table_name( $posts_table );
+
+		$post_types_placeholders        = array_fill( 0, count( $post_types ), '%s' );
+		$post_types_placeholders_csv    = implode( ',', $post_types_placeholders );
+		$post_statuses_placeholders     = array_fill( 0, count( $post_statuses ), '%s' );
+		$post_statuses_placeholders_csv = implode( ',', $post_statuses_placeholders );
+
+		// phpcs:disable -- table name was properly validated WordPress.DB.PreparedSQL.InterpolatedNotPrepared.
+		$sql_replace_table = $this->wpdb->prepare(
+			"SELECT COUNT(*) FROM {TABLE}
+				WHERE post_type IN ( $post_types_placeholders_csv )
+				AND post_status IN ( $post_statuses_placeholders_csv );",
+			array_merge( $post_types, $post_statuses )
+		);
+		$count = $this->wpdb->get_var( str_replace( '{TABLE}', $posts_table, $sql_replace_table ) );
+		// phpcs:enable
+
+		return (int) $count;
 	}
 
 	/**
@@ -708,8 +743,6 @@ class ContentDiffLogic {
 	 * Finds unique records in live posts table which don't exist in local posts table.
 	 * Uses old_id meta mapping for efficient O(1) lookup per post.
 	 *
-	 * Outputs progress by 10% increments to the CLI.
-	 *
 	 * @param array $results_live_posts Rows from live posts table.
 	 * @param array $local_old_id_map   Map of live_id => local_id from old_id postmeta.
 	 *
@@ -718,23 +751,12 @@ class ContentDiffLogic {
 	public function filter_new_live_ids( array $results_live_posts, array $local_old_id_map ): array {
 		$ids = [];
 
-		$progress = new Progress( count( $results_live_posts ), 20 );
-		foreach ( $results_live_posts as $key_live_post => $live_post ) {
-
-			// Output progress by 10%.
-			$progress_milestone = $progress->tick( $key_live_post + 1 );
-			if ( $progress_milestone ) {
-				Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, Progress::format( $progress_milestone ) );
-			}
-
+		foreach ( $results_live_posts as $live_post ) {
 			// O(1) lookup: if live ID is not in the old_id mapping, it's a new post.
 			$live_id = (int) $live_post['ID'];
 			if ( ! isset( $local_old_id_map[ $live_id ] ) ) {
 				$ids[] = $live_id;
 			}
-		}
-		if ( $progress->finish() ) {
-			Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, Progress::format( 100 ) );
 		}
 
 		return $ids;
@@ -1486,8 +1508,14 @@ class ContentDiffLogic {
 	 * Matches local posts to live posts using composite key hash mapping.
 	 * Similar pattern to filter_new_live_ids but returns local->live ID pairs.
 	 *
-	 * @param array $results_local_posts Rows from local posts table.
-	 * @param array $results_live_posts  Rows from live posts table.
+	 * Supports batched processing by building the $live_posts_lookup once from live posts,
+	 * then reusing it across multiple batches of local posts.
+	 *
+	 * @param array      $results_local_posts Rows from local posts table.
+	 * @param array      $results_live_posts  Rows from live posts table.
+	 * @param array|null $live_posts_lookup   Optional pre-built lookup hash (composite_key => live_id).
+	 *                                        Pass by reference to build once and reuse across batches.
+	 *                                        If null, builds from $results_live_posts.
 	 *
 	 * @return array {
 	 *     Array of matched post pairs with local_id and live_id.
@@ -1498,24 +1526,24 @@ class ContentDiffLogic {
 	 *     }
 	 * }
 	 */
-	public function match_local_to_live_posts( array $results_local_posts, array $results_live_posts ): array {
+	public function match_local_to_live_posts( array $results_local_posts, array $results_live_posts, ?array &$live_posts_lookup = null ): array {
 		$matches = [];
 
-		// Get posts composite hashes, and compare them to find matches.
-		
-		// Get hashes for live posts.
-		$live_posts_lookup = [];
-		foreach ( $results_live_posts as $live_post ) {
-			$lookup_key = $this->build_post_composite_key_for_post( $live_post );
-			
-			// Store composite key with live ID.
-			if ( ! isset( $live_posts_lookup[ $lookup_key ] ) ) {
-				$live_posts_lookup[ $lookup_key ] = (int) $live_post['ID'];
+		// Build lookup from live posts only if not already provided.
+		if ( null === $live_posts_lookup ) {
+			$live_posts_lookup = [];
+			foreach ( $results_live_posts as $live_post ) {
+				$lookup_key = $this->build_post_composite_key_for_post( $live_post );
+				
+				// Store composite key with live ID.
+				if ( ! isset( $live_posts_lookup[ $lookup_key ] ) ) {
+					$live_posts_lookup[ $lookup_key ] = (int) $live_post['ID'];
+				}
 			}
 		}
 
 		// Get hashes for local posts, and compare them to find matches.
-		foreach ( $results_local_posts as $key_local_post => $local_post ) {
+		foreach ( $results_local_posts as $local_post ) {
 			$lookup_key = $this->build_post_composite_key_for_post( $local_post );
 
 			// Found a match.

--- a/src/Logic/DataImporter.php
+++ b/src/Logic/DataImporter.php
@@ -576,7 +576,7 @@ class DataImporter {
 				// Log DEBUG info to CLI only once with the first example.
 				static $cli_warned_term_merge = false;
 				if ( false === $cli_warned_term_merge ) {
-					Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, sprintf( '- merge_term: Some terms already exist on local and are being merged/reused, and an additional meta is set for those terms. See %s for full list (first example: term_name `%s`, taxonomy `%s`, live_term_id=%d, local_term_id=%d).', Logger::instance()->get_log_file_path(), $term_name, $taxonomy_name, $live_term_id, $local_term_id ) );
+					Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, sprintf( '- merge_term FYI: Some terms already exist on local and are being merged/reused, and an additional meta is set for those terms. See %s for full list (first example: term_name `%s`, taxonomy `%s`, live_term_id=%d, local_term_id=%d).', Logger::instance()->get_log_file_path(), $term_name, $taxonomy_name, $live_term_id, $local_term_id ) );
 					$cli_warned_term_merge = true;
 				}
 			}
@@ -773,7 +773,7 @@ class DataImporter {
 				// Log DEBUG info to CLI only once with the first example.
 				static $cli_warned_user_merge = false;
 				if ( false === $cli_warned_user_merge ) {
-					Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, sprintf( '- merge_user: Some users already exist on local (same login) and are being merged/reused, and an additional meta is set for those users. See %s for full list (first example: user_login=`%s`, live_user_id=%d, local_user_id=%d).', Logger::instance()->get_log_file_path(), $user_row['user_login'], $user_row['ID'], $local_user_id ) );
+					Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, sprintf( '- merge_user FYI: Some users already exist on local (same login) and are being merged/reused, and an additional meta is set for those users. See %s for full list (first example: user_login=`%s`, live_user_id=%d, local_user_id=%d).', Logger::instance()->get_log_file_path(), $user_row['user_login'], $user_row['ID'], $local_user_id ) );
 					$cli_warned_user_merge = true;
 				}
 

--- a/src/Logic/DataImporter.php
+++ b/src/Logic/DataImporter.php
@@ -576,7 +576,7 @@ class DataImporter {
 				// Log DEBUG info to CLI only once with the first example.
 				static $cli_warned_term_merge = false;
 				if ( false === $cli_warned_term_merge ) {
-					Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, sprintf( '- merge_term FYI: Some terms already exist on local and are being merged/reused, and an additional meta is set for those terms. See %s for full list (first example: term_name `%s`, taxonomy `%s`, live_term_id=%d, local_term_id=%d).', Logger::instance()->get_log_file_path(), $term_name, $taxonomy_name, $live_term_id, $local_term_id ) );
+					Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, sprintf( '- merge_term info: Some terms already exist on local and are being merged/reused, and an additional meta is set for those terms. See %s for full list (first example: term_name `%s`, taxonomy `%s`, live_term_id=%d, local_term_id=%d).', Logger::instance()->get_log_file_path(), $term_name, $taxonomy_name, $live_term_id, $local_term_id ) );
 					$cli_warned_term_merge = true;
 				}
 			}
@@ -773,7 +773,7 @@ class DataImporter {
 				// Log DEBUG info to CLI only once with the first example.
 				static $cli_warned_user_merge = false;
 				if ( false === $cli_warned_user_merge ) {
-					Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, sprintf( '- merge_user FYI: Some users already exist on local (same login) and are being merged/reused, and an additional meta is set for those users. See %s for full list (first example: user_login=`%s`, live_user_id=%d, local_user_id=%d).', Logger::instance()->get_log_file_path(), $user_row['user_login'], $user_row['ID'], $local_user_id ) );
+					Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, sprintf( '- merge_user info: Some users already exist on local (same login) and are being merged/reused, and an additional meta is set for those users. See %s for full list (first example: user_login=`%s`, live_user_id=%d, local_user_id=%d).', Logger::instance()->get_log_file_path(), $user_row['user_login'], $user_row['ID'], $local_user_id ) );
 					$cli_warned_user_merge = true;
 				}
 

--- a/src/Logic/DataImporter.php
+++ b/src/Logic/DataImporter.php
@@ -605,9 +605,9 @@ class DataImporter {
 	 * Ensures a taxonomy is registered if it doesn't exist.
 	 *
 	 * @param string $taxonomy_name          Taxonomy name.
-	 * @param array  $live_term_taxonomy_row Live term taxonomy row (used to determine if hierarchical).
+	 * @param array  $live_term_taxonomy_row Optional. Live term taxonomy row (used to determine if hierarchical).
 	 */
-	private function ensure_taxonomy_registered( string $taxonomy_name, array $live_term_taxonomy_row ): void {
+	public function ensure_taxonomy_registered( string $taxonomy_name, array $live_term_taxonomy_row = [] ): void {
 		if ( taxonomy_exists( $taxonomy_name ) ) {
 			return;
 		}

--- a/tests/unit/Logic/ContentDiffLogicTest.php
+++ b/tests/unit/Logic/ContentDiffLogicTest.php
@@ -289,6 +289,157 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'post_modified', $first );
 	}
 
+	public function test_get_posts_rows_for_content_diff_with_limit_should_return_limited_results(): void {
+		global $wpdb;
+
+		// Create 5 posts.
+		for ( $i = 0; $i < 5; $i++ ) {
+			self::factory()->post->create(
+				[
+					'post_type'   => 'post',
+					'post_status' => 'publish',
+				]
+			);
+		}
+
+		$result = $this->logic->get_posts_rows_for_content_diff(
+			$wpdb->posts,
+			[ 'post' ],
+			[ 'publish' ],
+			2 // Limit to 2.
+		);
+
+		$this->assertCount( 2, $result );
+	}
+
+	public function test_get_posts_rows_for_content_diff_with_offset_should_skip_rows(): void {
+		global $wpdb;
+
+		// Create 5 posts with predictable titles.
+		$post_ids = [];
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$post_ids[] = self::factory()->post->create(
+				[
+					'post_type'   => 'post',
+					'post_status' => 'publish',
+					'post_title'  => "Post {$i}",
+				]
+			);
+		}
+		sort( $post_ids ); // IDs in ascending order.
+
+		// Get posts with offset 2, limit 2.
+		$result = $this->logic->get_posts_rows_for_content_diff(
+			$wpdb->posts,
+			[ 'post' ],
+			[ 'publish' ],
+			2,
+			2
+		);
+
+		$this->assertCount( 2, $result );
+		// Results should be ordered by ID ASC, so offset 2 should skip first 2 IDs.
+		$result_ids = array_column( $result, 'ID' );
+		$this->assertContains( (string) $post_ids[2], $result_ids );
+		$this->assertContains( (string) $post_ids[3], $result_ids );
+	}
+
+	public function test_get_posts_rows_for_content_diff_batching_should_cover_all_rows(): void {
+		global $wpdb;
+
+		// Create 5 posts.
+		$created_ids = [];
+		for ( $i = 0; $i < 5; $i++ ) {
+			$created_ids[] = self::factory()->post->create(
+				[
+					'post_type'   => 'post',
+					'post_status' => 'publish',
+				]
+			);
+		}
+
+		// Fetch in batches of 2.
+		$all_results = [];
+		$batch_size  = 2;
+		$offset      = 0;
+		do {
+			$batch       = $this->logic->get_posts_rows_for_content_diff(
+				$wpdb->posts,
+				[ 'post' ],
+				[ 'publish' ],
+				$batch_size,
+				$offset
+			);
+			$all_results  = array_merge( $all_results, $batch );
+			$batch_count  = count( $batch );
+			$offset      += $batch_size;
+		} while ( $batch_count === $batch_size );
+
+		// Should have fetched all 5 posts.
+		$fetched_ids = array_map( 'intval', array_column( $all_results, 'ID' ) );
+		foreach ( $created_ids as $id ) {
+			$this->assertContains( $id, $fetched_ids );
+		}
+	}
+
+	/**
+	 * =========================================================================
+	 * count_posts_for_content_diff Tests
+	 * =========================================================================
+	 */
+	public function test_count_posts_for_content_diff_should_return_correct_count(): void {
+		global $wpdb;
+
+		// Create 3 posts.
+		for ( $i = 0; $i < 3; $i++ ) {
+			self::factory()->post->create(
+				[
+					'post_type'   => 'post',
+					'post_status' => 'publish',
+				]
+			);
+		}
+
+		$count = $this->logic->count_posts_for_content_diff(
+			$wpdb->posts,
+			[ 'post' ],
+			[ 'publish' ]
+		);
+
+		$this->assertGreaterThanOrEqual( 3, $count );
+	}
+
+	public function test_count_posts_for_content_diff_should_return_zero_for_no_matches(): void {
+		global $wpdb;
+
+		$count = $this->logic->count_posts_for_content_diff(
+			$wpdb->posts,
+			[ 'nonexistent_type' ],
+			[ 'publish' ]
+		);
+
+		$this->assertSame( 0, $count );
+	}
+
+	public function test_count_posts_for_content_diff_should_match_get_posts_count(): void {
+		global $wpdb;
+
+		// Create some posts.
+		for ( $i = 0; $i < 4; $i++ ) {
+			self::factory()->post->create(
+				[
+					'post_type'   => 'post',
+					'post_status' => 'publish',
+				]
+			);
+		}
+
+		$count  = $this->logic->count_posts_for_content_diff( $wpdb->posts, [ 'post' ], [ 'publish' ] );
+		$result = $this->logic->get_posts_rows_for_content_diff( $wpdb->posts, [ 'post' ], [ 'publish' ] );
+
+		$this->assertSame( $count, count( $result ) );
+	}
+
 	/**
 	 * =========================================================================
 	 * get_imported_post_id_mapping_from_db Tests (Attachments)
@@ -1007,6 +1158,127 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 
 		$this->assertSame( 10, $result[0]['local_id'] );
 		$this->assertSame( 1, $result[0]['live_id'] );
+	}
+
+	public function test_match_local_to_live_posts_with_prebuilt_lookup_should_reuse_lookup(): void {
+		$live_posts = [
+			[
+				'ID'          => '1',
+				'post_name'   => 'post-a',
+				'post_title'  => 'Post A',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_date'   => '2025-01-01',
+			],
+			[
+				'ID'          => '2',
+				'post_name'   => 'post-b',
+				'post_title'  => 'Post B',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_date'   => '2025-01-02',
+			],
+		];
+
+		// Build lookup from live posts (first call with empty local posts).
+		$lookup = null;
+		$result = $this->logic->match_local_to_live_posts( [], $live_posts, $lookup );
+
+		// Verify lookup was built.
+		$this->assertIsArray( $lookup );
+		$this->assertNotEmpty( $lookup );
+		$this->assertEmpty( $result, 'No matches expected with empty local posts.' );
+
+		// Now use the pre-built lookup with local posts (empty live posts array).
+		$local_posts_batch1 = [
+			[
+				'ID'          => '10',
+				'post_name'   => 'post-a',
+				'post_title'  => 'Post A',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_date'   => '2025-01-01',
+			],
+		];
+
+		$result1 = $this->logic->match_local_to_live_posts( $local_posts_batch1, [], $lookup );
+
+		$this->assertCount( 1, $result1 );
+		$this->assertSame( 10, $result1[0]['local_id'] );
+		$this->assertSame( 1, $result1[0]['live_id'] );
+
+		// Second batch reusing the same lookup.
+		$local_posts_batch2 = [
+			[
+				'ID'          => '20',
+				'post_name'   => 'post-b',
+				'post_title'  => 'Post B',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_date'   => '2025-01-02',
+			],
+		];
+
+		$result2 = $this->logic->match_local_to_live_posts( $local_posts_batch2, [], $lookup );
+
+		$this->assertCount( 1, $result2 );
+		$this->assertSame( 20, $result2[0]['local_id'] );
+		$this->assertSame( 2, $result2[0]['live_id'] );
+	}
+
+	public function test_match_local_to_live_posts_with_prebuilt_lookup_should_not_rebuild(): void {
+		$live_posts = [
+			[
+				'ID'          => '1',
+				'post_name'   => 'original',
+				'post_title'  => 'Original',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_date'   => '2025-01-01',
+			],
+		];
+
+		// Build lookup.
+		$lookup = null;
+		$this->logic->match_local_to_live_posts( [], $live_posts, $lookup );
+		$lookup_count_after_build = count( $lookup );
+
+		// Call again with different live posts — lookup should NOT be rebuilt.
+		$different_live_posts = [
+			[
+				'ID'          => '999',
+				'post_name'   => 'different',
+				'post_title'  => 'Different',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_date'   => '2025-01-01',
+			],
+		];
+
+		$this->logic->match_local_to_live_posts( [], $different_live_posts, $lookup );
+
+		// Lookup should still have original count (not rebuilt with different_live_posts).
+		$this->assertCount( $lookup_count_after_build, $lookup );
+	}
+
+	public function test_match_local_to_live_posts_with_empty_prebuilt_lookup_finds_no_matches(): void {
+		// Pre-built empty lookup (simulating no live posts).
+		$lookup = [];
+
+		$local_posts = [
+			[
+				'ID'          => '10',
+				'post_name'   => 'some-post',
+				'post_title'  => 'Some Post',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_date'   => '2025-01-01',
+			],
+		];
+
+		$result = $this->logic->match_local_to_live_posts( $local_posts, [], $lookup );
+
+		$this->assertEmpty( $result );
 	}
 
 	/**

--- a/tests/unit/Logic/ContentDiffLogicTest.php
+++ b/tests/unit/Logic/ContentDiffLogicTest.php
@@ -370,9 +370,9 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 				$batch_size,
 				$offset
 			);
-			$all_results  = array_merge( $all_results, $batch );
-			$batch_count  = count( $batch );
-			$offset      += $batch_size;
+			$all_results = array_merge( $all_results, $batch );
+			$batch_count = count( $batch );
+			$offset     += $batch_size;
 		} while ( $batch_count === $batch_size );
 
 		// Should have fetched all 5 posts.


### PR DESCRIPTION
Introducing some memory optimizations, so that it can run on larger DBs. This was tested on TT's DB, and now passes.

Since this is just a smaller improvement upon v.2 which is being tested right now, merging to trunk as a part of that effort.

Note that even more optimizations will probably  be needed in future, so we will improve gradually when we meet such examples IRL.

### Memory optimizations

**1. `search` command -- automat(t)ic attribution now batched**

Both post objects and attachments are now attributed in safe batches of 20k objects,
- added the count method and extended get_posts_rows_for_content_diff with LIMIT/OFFSET
- refactored attachment attribution to process in batches
- there's a constant in the command class `const MEMORY_SAFE_BATCH_SIZE = 20000;`

Batching in action (the CLI output still remains slim and readable, and action/debug file log gets full details):

<img width="1118" height="325" alt="image" src="https://github.com/user-attachments/assets/ec86f9d9-3ba4-48f0-bf33-df579eedb957" />

**2. `search` command -- searching new/modified attachments now batched**

- search phase was previously loading all the live attachments into memory at once, which was too much for very large DBs (in TT's case, that was 94,022 attachments). Now searching these in safe batches
- added more MemoryCleanupHook::cleanup flushes in logic class, too

**Note** -- have _not_ added batching for non-attachment post objects' search just yet -- this would be a bit more complex because, of internal hash lookups and comparisons, but there is room for improvement here, if it will also become necessary

**3. Newspack Data Consistency standard**
- added more memory flushes when checking for modifield fields in several places (e.g. in `update_modified_attachments()`)

### Future optimizations

If more memory optimization will be needed in the future for more sites, we can introduce more optimizations:
- extend other parts of code in a similar way, where failing will occur
- we can even temporarily extend the WP Cloud site's memory for the CDiff to more safely run, then put memory back to what it was after migration


## How to test
- run on a bit larger site, possibly using Knife CDiff https://github.com/Automattic/newspack-launch-army-knife/pull/194

---

- [x] confirmed that PHPCS has been run
