### PR TITLE
Fix false positive modified. Hardening for invalid DB data. Full MDCS test coverage. Faster posts deletion. Cleaner CLI output.

### DIFF
--- a/newspack-content-diff-migrator.php
+++ b/newspack-content-diff-migrator.php
@@ -5,7 +5,7 @@
  * Plugin URI:  https://newspack.com
  * Author:      Automattic
  * Author URI:  https://newspack.com
- * Version:     2.1.0
+ * Version:     2.1.1
  *
  * @package  Newspack_Content_Diff_Migrator
  */

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -566,7 +566,8 @@ class ContentDiffMigrator {
 				$live_table_prefix,
 				$user_old_id_map,
 				$attachment_old_id_map,
-				$term_old_id_map
+				$term_old_id_map,
+				$taxonomies
 			);
 			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( '%d modified IDs found (see %s).', count( $modified_live_ids ), rtrim( $data_dir, '/' ) . '/run-state/' . RunState::FILE_MODIFIED_IDS ) );
 			MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -454,7 +454,7 @@ class ContentDiffMigrator {
 
 		if ( $unattributed['count'] > 0 ) {
 			// Auto-match unattributed content to live tables and attribute matches.
-			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( 'There are %d total objects on local without any `%s*` metas. Trying to automatically attribute this content by matching it with live tables...', $unattributed['count'], ContentDiffLogic::SAVED_META_LIVE_ID_PREFIX ) );
+			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( 'There are %d total objects on local without `%s*` metas. Trying to automatically attribute this content by matching it with live tables...', $unattributed['count'], ContentDiffLogic::SAVED_META_LIVE_ID_PREFIX ) );
 			$attribution_counts = $this->do_attribution_match_to_live_tables(
 				$live_table_prefix,
 				$source_hostname,
@@ -483,7 +483,7 @@ class ContentDiffMigrator {
 					Logger::OUTPUT_BOTH,
 					LogLevel::DEBUG,
 					sprintf(
-						'There are %d total objects original to staging/local, without any `%s*` metas, see %s for their IDs.',
+						'There are %d original objects on staging/local without `%s*` metas, see %s for their IDs.',
 						$remaining['count'],
 						ContentDiffLogic::SAVED_META_LIVE_ID_PREFIX,
 						$remaining['file_path']
@@ -1273,7 +1273,7 @@ class ContentDiffMigrator {
 				Logger::OUTPUT_BOTH,
 				LogLevel::DEBUG,
 				sprintf(
-					'There are %d total objects original to staging/local, without any `%s*` metas, see %s for their IDs.',
+					'There are %d original objects on staging/local without `%s*` metas, see %s for their IDs.',
 					$remaining['count'],
 					ContentDiffLogic::SAVED_META_LIVE_ID_PREFIX,
 					$remaining['file_path']

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -405,7 +405,7 @@ class ContentDiffMigrator {
 		try {
 			$this->db->validate_db_tables( $live_table_prefix, [ 'options' ] );
 		} catch ( \RuntimeException $e ) {
-			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::ERROR, $e->getMessage() . " About to run `newspack-content-migrator correct-collations-for-live-wp-tables --live-table-prefix={$live_table_prefix} --skip-tables=options` ..." );
+			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::WARNING, $e->getMessage() . " About to run `newspack-content-migrator correct-collations-for-live-wp-tables --live-table-prefix={$live_table_prefix} --skip-tables=options` ..." );
 			$this->cmd_correct_collations_for_live_wp_tables(
 				[],
 				[
@@ -1556,9 +1556,9 @@ class ContentDiffMigrator {
 		}
 
 		// Update parent IDs.
-		$dispayed_cli_error_get_local_id     = false;
-		$dispayed_cli_warning_update_parents = false;
-		$progress                            = new Progress( count( $live_ids_for_parents_update ), 20 );
+		$displayed_cli_warning_get_local_id   = false;
+		$displayed_cli_warning_update_parents = false;
+		$progress                             = new Progress( count( $live_ids_for_parents_update ), 20 );
 		foreach ( $live_ids_for_parents_update as $key_id_old => $id_old ) {
 			// Output progress by 10%.
 			$progress_milestone = $progress->tick( $key_id_old + 1 );
@@ -1569,10 +1569,10 @@ class ContentDiffMigrator {
 			// Get new local Post ID.
 			$id_new = $imported_ids_map[ $id_old ] ?? null;
 			if ( null === $id_new ) {
-				Logger::instance()->log( Logger::OUTPUT_FILE, LogLevel::ERROR, sprintf( 'update_post_parent_ids: live ID %d has no local mapping, skipping.', $id_old ) );
-				if ( false === $dispayed_cli_error_get_local_id ) {
-					Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::ERROR, sprintf( 'update_post_parent_ids: some live IDs have no local mapping. See %s for full list (first example: $id_old=%s).', Logger::instance()->get_log_file_path(), $id_old ) );
-					$dispayed_cli_error_get_local_id = true;
+				Logger::instance()->log( Logger::OUTPUT_FILE, LogLevel::WARNING, sprintf( 'update_post_parent_ids: live ID %d has no local mapping, skipping.', $id_old ) );
+				if ( false === $displayed_cli_warning_get_local_id ) {
+					Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::WARNING, sprintf( 'update_post_parent_ids: some live IDs have no local mapping. See %s for full list (first example: $id_old=%s).', Logger::instance()->get_log_file_path(), $id_old ) );
+					$displayed_cli_warning_get_local_id = true;
 				}
 				continue;
 			}
@@ -1625,9 +1625,9 @@ class ContentDiffMigrator {
 						'parent_id_old' => $parent_id_old,
 					] 
 				);
-				if ( false === $dispayed_cli_warning_update_parents ) {
+				if ( false === $displayed_cli_warning_update_parents ) {
 					Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::WARNING, sprintf( 'update_post_parent_ids: some parent IDs not found on live. This is usually not an error (happens when parent_ids are not found on live, or are different post types that are not being migrated). See %s for full list (first example: $id_old=%s, $id_new=%s, $parent_id_old=%s; $parent_id_new set to 0).', Logger::instance()->get_log_file_path(), $id_old, $id_new, $parent_id_old ) );
-					$dispayed_cli_warning_update_parents = true;
+					$displayed_cli_warning_update_parents = true;
 				}
 			}
 

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -795,31 +795,76 @@ class ContentDiffMigrator {
 				Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( '%d posts were already deleted, continuing from there...', $already_deleted_count ) );
 			}
 			
-			// Delete modified posts so they can be re-imported.
-			foreach ( $local_ids_to_delete as $key_delete => $id ) {
-				$deleted = wp_delete_post( $id, true );
-				if ( false === $deleted || null === $deleted ) {
-					$context = [
-						'local_id' => $id,
-						'live_id'  => array_search( $id, $modified_ids_map ),
-					];
-					Logger::instance()->log_brief_and_verbose( LogLevel::ERROR, sprintf( 'Failed to delete modified post local ID %d, this post will not be updated/reimported.', $id ), $context );
-					// Don't continue and save to run-state if deletion failed.
-					continue;
-				}
-				MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1, $key_delete, 300 );
+			// Batch delete modified posts for speed, so they can be re-imported.
+			$batch_size        = 500;
+			$offset            = 0;
+			$total_to_delete   = count( $local_ids_to_delete );
+			$failed_delete_ids = [];
+			while ( $offset < $total_to_delete ) {
+				$batch        = array_slice( $local_ids_to_delete, $offset, $batch_size );
+				$placeholders = implode( ',', array_fill( 0, count( $batch ), '%d' ) );
 
-				// Save run-state info that this modified ID was deleted.
-				$this->run_state->append_deleted_modified_id(
-					[
-						'live_id'  => array_search( $id, $modified_ids_map ),
-						'local_id' => $id,
-					] 
-				);
+				// Uses single-table DELETE IGNORE to ensure individual row failures don't prevent other rows from being deleted.
+
+				// Delete revisions' metas and term_relationships (subquery finds revision IDs), then revisions.
+				// phpcs:disable -- $placeholders is safely constructedWordPress.DB.PreparedSQL.InterpolatedNotPrepared.
+				$wpdb->query( $wpdb->prepare( "DELETE IGNORE FROM {$wpdb->postmeta} WHERE post_id IN (SELECT ID FROM {$wpdb->posts} WHERE post_parent IN ($placeholders) AND post_type = 'revision')", $batch ) );
+				$wpdb->query( $wpdb->prepare( "DELETE IGNORE FROM {$wpdb->term_relationships} WHERE object_id IN (SELECT ID FROM {$wpdb->posts} WHERE post_parent IN ($placeholders) AND post_type = 'revision')", $batch ) );
+				$wpdb->query( $wpdb->prepare( "DELETE IGNORE FROM {$wpdb->posts} WHERE post_parent IN ($placeholders) AND post_type = 'revision'", $batch ) );
+				// phpcs:enable
+				
+				// Delete commentmeta (subquery finds comment IDs), comments.
+				// phpcs:disable -- $placeholders is safely constructedWordPress.DB.PreparedSQL.InterpolatedNotPrepared.
+				$wpdb->query( $wpdb->prepare( "DELETE IGNORE FROM {$wpdb->commentmeta} WHERE comment_id IN (SELECT comment_ID FROM {$wpdb->comments} WHERE comment_post_ID IN ($placeholders))", $batch ) );
+				$wpdb->query( $wpdb->prepare( "DELETE IGNORE FROM {$wpdb->comments} WHERE comment_post_ID IN ($placeholders)", $batch ) );
+				// phpcs:enable
+
+				// Delete postmeta, term_relationships, posts.
+				// phpcs:disable -- $placeholders is safely constructedWordPress.DB.PreparedSQL.InterpolatedNotPrepared.
+				$wpdb->query( $wpdb->prepare( "DELETE IGNORE FROM {$wpdb->postmeta} WHERE post_id IN ($placeholders)", $batch ) );
+				$wpdb->query( $wpdb->prepare( "DELETE IGNORE FROM {$wpdb->term_relationships} WHERE object_id IN ($placeholders)", $batch ) );
+				$wpdb->query( $wpdb->prepare( "DELETE IGNORE FROM {$wpdb->posts} WHERE ID IN ($placeholders)", $batch ) );
+				// phpcs:enable
+
+				// Check if some IDs failed to be deleted and track for exclusion from reimport.
+				$still_exist = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE ID IN ($placeholders)", $batch ) ); // phpcs:ignore -- $placeholders is safely constructedWordPress.DB.PreparedSQL.InterpolatedNotPrepared.
+				foreach ( $still_exist as $failed_id ) {
+					$failed_delete_ids[] = (int) $failed_id;
+					Logger::instance()->log_brief_and_verbose(
+						LogLevel::ERROR,
+						sprintf( 'Failed to delete modified post local ID %d, this post will not be updated/reimported.', $failed_id ),
+						[
+							'local_id' => $failed_id,
+							'live_id'  => array_search( $failed_id, $modified_ids_map ),
+						]
+					);
+				}
+
+				// Save run-state for successfully deleted IDs.
+				foreach ( array_diff( $batch, $still_exist ) as $deleted_id ) {
+					$this->run_state->append_deleted_modified_id(
+						[
+							'live_id'  => array_search( $deleted_id, $modified_ids_map ),
+							'local_id' => $deleted_id,
+						]
+					);
+				}
+				
+				// Update offset for next batch.
+				$offset += $batch_size;
+
+				// One cache flush per batch.
+				MemoryCleanupHook::cleanup( $this->test_env ? 0 : 1 );
 			}
 
-			// Merge modified posts IDs with $all_live_posts_ids for reimport.
-			$new_live_ids = array_merge( $new_live_ids, array_keys( $modified_ids_map ) );
+			// Merge only successfully deleted modified posts for reimport (exclude failed).
+			$live_ids_to_reimport = [];
+			foreach ( $modified_ids_map as $live_id => $local_id ) {
+				if ( ! in_array( $local_id, $failed_delete_ids, true ) ) {
+					$live_ids_to_reimport[] = $live_id;
+				}
+			}
+			$new_live_ids = array_merge( $new_live_ids, $live_ids_to_reimport );
 		}
 
 		// If no new/modified posts to migrate, return early.

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -483,9 +483,10 @@ class ContentDiffMigrator {
 					Logger::OUTPUT_FILE,
 					LogLevel::DEBUG,
 					sprintf(
-						'There are %d total objects remaining on local without any `%s*` metas.',
+						'There are %d total objects original to staging/local, without any `%s*` metas, see %s for their IDs.',
 						$remaining['count'],
-						ContentDiffLogic::SAVED_META_LIVE_ID_PREFIX
+						ContentDiffLogic::SAVED_META_LIVE_ID_PREFIX,
+						$remaining['file_path']
 					)
 				);
 			}
@@ -804,8 +805,7 @@ class ContentDiffMigrator {
 				$batch        = array_slice( $local_ids_to_delete, $offset, $batch_size );
 				$placeholders = implode( ',', array_fill( 0, count( $batch ), '%d' ) );
 
-				// Uses single-table DELETE IGNORE to ensure individual row failures don't prevent other rows from being deleted.
-
+				// Using single table DELETE IGNORE to ensure that individual row failures don't prevent other rows in the batch from being deleted.
 				// Delete revisions' metas and term_relationships (subquery finds revision IDs), then revisions.
 				// phpcs:disable -- $placeholders is safely constructedWordPress.DB.PreparedSQL.InterpolatedNotPrepared.
 				$wpdb->query( $wpdb->prepare( "DELETE IGNORE FROM {$wpdb->postmeta} WHERE post_id IN (SELECT ID FROM {$wpdb->posts} WHERE post_parent IN ($placeholders) AND post_type = 'revision')", $batch ) );
@@ -1275,7 +1275,7 @@ class ContentDiffMigrator {
 				Logger::OUTPUT_BOTH,
 				LogLevel::DEBUG,
 				sprintf(
-					'There are %d total objects on local without any `%s*` metas. See %s for full IDs.',
+					'There are %d total objects original to staging/local, without any `%s*` metas, see %s for their IDs.',
 					$remaining['count'],
 					ContentDiffLogic::SAVED_META_LIVE_ID_PREFIX,
 					$remaining['file_path']

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -480,13 +480,12 @@ class ContentDiffMigrator {
 			$remaining = $this->check_unattributed_content( $post_types );
 			if ( $remaining['count'] > 0 ) {
 				Logger::instance()->log(
-					Logger::OUTPUT_BOTH,
+					Logger::OUTPUT_FILE,
 					LogLevel::DEBUG,
 					sprintf(
-						'There are %d total objects remaining on local without any `%s*` metas. See %s for full IDs. If this is new local content from Newspackification, it is perfectly safe to continue. Otherwise see README and the `attribute-ids` command to set the "old ID and source hostname" metas if this content belongs to the same source hostname (e.g. was migrated by some other migration tool).',
+						'There are %d total objects remaining on local without any `%s*` metas.',
 						$remaining['count'],
-						ContentDiffLogic::SAVED_META_LIVE_ID_PREFIX,
-						$remaining['file_path']
+						ContentDiffLogic::SAVED_META_LIVE_ID_PREFIX
 					)
 				);
 			}

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -1049,9 +1049,6 @@ class ContentDiffMigrator {
 			] 
 		);
 
-		// Confirm action.
-		$this->attribute_confirm_action( sprintf( 'This will attribute specified ID pairs from JSONL files to %s.', $source_hostname ) );
-
 		// Variables.
 		global $wpdb;
 		$meta_key        = $this->logic->get_old_id_meta_key( $source_hostname );
@@ -1800,18 +1797,6 @@ class ContentDiffMigrator {
 			if ( ! is_wp_error( $terms ) && $terms ) {
 				wp_update_term_count_now( $terms, $taxonomy );
 			}
-		}
-	}
-
-	/**
-	 * Confirms attribution action with user (unless test environment).
-	 *
-	 * @param string $message Confirmation message.
-	 */
-	private function attribute_confirm_action( string $message ): void {
-		Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, $message );
-		if ( ! $this->test_env ) {
-			WP_CLI::confirm( 'Continue?' );
 		}
 	}
 

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -628,7 +628,7 @@ class ContentDiffMigrator {
 		Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( 'Full logs were saved to %s:', rtrim( (string) $data_dir, '/' ) ) );
 		Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( '- debug/action log: %s', basename( Logger::instance()->get_log_file_path() ?? '' ) ) );
 		Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( '- run-state manifest: %s', RunState::FILE_MANIFEST ) );
-		Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, 'All done searching for new content on live 🙌  Proceed by running the `migrate-live-content` command 🚀' );
+		Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, 'All done searching for new content on live 🙌  Proceed to run the `migrate-live-content` command 🚀' );
 	}
 
 	/**

--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -480,7 +480,7 @@ class ContentDiffMigrator {
 			$remaining = $this->check_unattributed_content( $post_types );
 			if ( $remaining['count'] > 0 ) {
 				Logger::instance()->log(
-					Logger::OUTPUT_FILE,
+					Logger::OUTPUT_BOTH,
 					LogLevel::DEBUG,
 					sprintf(
 						'There are %d total objects original to staging/local, without any `%s*` metas, see %s for their IDs.',

--- a/src/Logic/ContentDiffLogic.php
+++ b/src/Logic/ContentDiffLogic.php
@@ -781,9 +781,10 @@ class ContentDiffLogic {
 	 * @param array  $results_local_posts   Rows from local posts table (must include ID, post_modified, post_status, post_author).
 	 * @param array  $local_old_id_map      Map of live_id => local_id from old_id postmeta.
 	 * @param string $live_table_prefix     Live DB table prefix (for fetching additional data).
-	 * @param array  $user_old_id_map       Optional. Map of live_user_id => local_user_id.
-	 * @param array  $attachment_old_id_map Optional. Map of live_attachment_id => local_attachment_id.
-	 * @param array  $term_old_id_map       Optional. Map of live_term_id => local_term_id.
+	 * @param array  $user_old_id_map       Map of live_user_id => local_user_id. Pass empty array if not checking author changes.
+	 * @param array  $attachment_old_id_map Map of live_attachment_id => local_attachment_id. Pass empty array if not checking thumbnail changes.
+	 * @param array  $term_old_id_map       Map of live_term_id => local_term_id. Pass empty array if not checking taxonomy changes.
+	 * @param array  $taxonomies            Taxonomies to compare for modifications (e.g., DEFAULT_TAXONOMIES). Only terms in these taxonomies are compared.
 	 *
 	 * @return array {
 	 *     Array of modified post ID pairs.
@@ -799,10 +800,11 @@ class ContentDiffLogic {
 		array $results_live_posts,
 		array $results_local_posts,
 		array $local_old_id_map,
-		string $live_table_prefix = '',
-		array $user_old_id_map = [],
-		array $attachment_old_id_map = [],
-		array $term_old_id_map = []
+		string $live_table_prefix,
+		array $user_old_id_map,
+		array $attachment_old_id_map,
+		array $term_old_id_map,
+		array $taxonomies
 	): array {
 		$ids_modified = [];
 
@@ -915,6 +917,7 @@ class ContentDiffLogic {
 			}
 
 			// Check 6: taxonomies changed (compare term sets).
+			// Only compare terms in the specified taxonomies (those that were attributed).
 			if ( ! empty( $local_to_live_term_map ) && ! empty( $live_table_prefix ) ) {
 				// Get live term IDs with their details.
 				$live_term_relationships = $this->select_term_relationships_rows( $live_table_prefix, $live_id );
@@ -924,6 +927,10 @@ class ContentDiffLogic {
 					$term_taxonomy = $this->select_term_taxonomy_row( $live_table_prefix, $relationship['term_taxonomy_id'] );
 					// Get details for the live terms.
 					if ( $term_taxonomy ) {
+						// Skip comparing taxonomies which are not in the attributed list (not being migrated).
+						if ( ! empty( $taxonomies ) && ! in_array( $term_taxonomy['taxonomy'], $taxonomies, true ) ) {
+							continue;
+						}
 						$term_id                       = (int) $term_taxonomy['term_id'];
 						$live_term_ids[]               = $term_id;
 						$live_term_details[ $term_id ] = [
@@ -939,6 +946,10 @@ class ContentDiffLogic {
 				foreach ( $local_term_relationships as $relationship ) {
 					$term_taxonomy = $this->select_term_taxonomy_row( $this->wpdb->prefix, $relationship['term_taxonomy_id'] );
 					if ( $term_taxonomy ) {
+						// Skip comparing taxonomies which are not in the attributed list (not being migrated).
+						if ( ! empty( $taxonomies ) && ! in_array( $term_taxonomy['taxonomy'], $taxonomies, true ) ) {
+							continue;
+						}
 						$local_terms[] = (int) $term_taxonomy['term_id'];
 					}
 				}

--- a/src/Logic/ContentDiffLogic.php
+++ b/src/Logic/ContentDiffLogic.php
@@ -483,37 +483,54 @@ class ContentDiffLogic {
 	}
 
 	/**
-	 * Matches local terms to live terms by slug and taxonomy.
+	 * Matches local terms to their corresponding live terms for attribution.
 	 *
-	 * @param array $results_local_terms Rows from local terms table.
-	 * @param array $results_live_terms  Rows from live terms table.
+	 * Uses priority-based matching -- based on ID, and on slug+taxonomy -- to handle edge
+	 * cases like duplicate term slugs (if live DB terms are invalid, which actually does happen IRL,
+	 * even though WP normally enforces unique slugs per taxonomy):
+	 * - Priority 1: direct term_id match, if the local term's ID exists on live
+	 * - Priority 2: {slug}|{taxonomy}, fallback for regular non-corrupt data
 	 *
-	 * @return array {
-	 *     Array of matched term pairs with local_id and live_id.
+	 * This kind of matching prevents false positive "modified" detection when duplicate term
+	 *  slugs exist, and cause the wrong live term ID to be attributed to a local term.
 	 *
-	 *     @type array $match {
-	 *         @type int $local_id Local term ID.
-	 *         @type int $live_id  Live term ID.
-	 *     }
-	 * }
+	 * @param array $results_local_terms Local terms with keys: term_id, slug, taxonomy.
+	 * @param array $results_live_terms  Live terms with keys: term_id, slug, taxonomy.
+	 *
+	 * @return array Array of ['local_id' => int, 'live_id' => int] mappings.
 	 */
 	public function match_local_to_live_terms( array $results_local_terms, array $results_live_terms ): array {
 		$matched_terms = [];
 
-		// Live terms lookup by slug + taxonomy composite key.
-		$live_terms_lookup = [];
+		// Build two lookups: by ID and by slug|taxonomy.
+		$live_terms_by_id  = [];
+		$live_terms_by_key = [];
 		foreach ( $results_live_terms as $live_term ) {
-			$lookup_key                       = $live_term['slug'] . '|' . $live_term['taxonomy'];
-			$live_terms_lookup[ $lookup_key ] = (int) $live_term['term_id'];
+			$term_id    = (int) $live_term['term_id'];
+			$lookup_key = $live_term['slug'] . '|' . $live_term['taxonomy'];
+
+			$live_terms_by_id[ $term_id ]       = true;
+			$live_terms_by_key[ $lookup_key ][] = $term_id;
 		}
 
 		foreach ( $results_local_terms as $local_term ) {
-			$lookup_key = $local_term['slug'] . '|' . $local_term['taxonomy'];
-			// Term is matched.
-			if ( isset( $live_terms_lookup[ $lookup_key ] ) ) {
+			$local_term_id = (int) $local_term['term_id'];
+			$lookup_key    = $local_term['slug'] . '|' . $local_term['taxonomy'];
+
+			// Priority 1: ID match, when local term_id exists on live.
+			if ( isset( $live_terms_by_id[ $local_term_id ] ) ) {
 				$matched_terms[] = [
-					'local_id' => (int) $local_term['term_id'],
-					'live_id'  => $live_terms_lookup[ $lookup_key ],
+					'local_id' => $local_term_id,
+					'live_id'  => $local_term_id,
+				];
+				continue;
+			}
+
+			// Priority 2: slug+taxonomy fallback.
+			if ( isset( $live_terms_by_key[ $lookup_key ] ) ) {
+				$matched_terms[] = [
+					'local_id' => $local_term_id,
+					'live_id'  => $live_terms_by_key[ $lookup_key ][0],
 				];
 			}
 		}

--- a/src/Logic/ContentDiffLogic.php
+++ b/src/Logic/ContentDiffLogic.php
@@ -840,6 +840,9 @@ class ContentDiffLogic {
 		// Flip term map for reverse lookup (local_id => live_id).
 		$local_to_live_term_map = ! empty( $term_old_id_map ) ? array_flip( $term_old_id_map ) : [];
 
+		// Get orphaned term_ids to be handled properly, for O(1) lookup. Orphaned terms are rare and this will not add much to memory usage.
+		$orphaned_term_ids = ! empty( $live_table_prefix ) ? $this->get_orphaned_term_ids( $live_table_prefix ) : [];
+
 		$progress = new Progress( count( $results_live_posts ), 20 );
 		foreach ( $results_live_posts as $key_live_post => $live_post ) {
 
@@ -949,9 +952,8 @@ class ContentDiffLogic {
 							continue;
 						}
 						$term_id = (int) $term_taxonomy['term_id'];
-						// Skip orphaned terms on live (handle cases where term_taxonomy exists but term row doesn't).
-						$term_row = $this->select_term_row( $live_table_prefix, $term_id );
-						if ( ! $term_row ) {
+						// Skip orphaned terms (term_taxonomy exists but term row doesn't).
+						if ( in_array( $term_id, $orphaned_term_ids, true ) ) {
 							continue;
 						}
 						$live_term_ids[]               = $term_id;
@@ -2041,6 +2043,26 @@ class ContentDiffLogic {
 	 */
 	public function select_term_row( string $table_prefix, int $term_id ): ?array {
 		return $this->select( $table_prefix . 'terms', [ 'term_id' => $term_id ], $select_just_one_row = true );
+	}
+
+	/**
+	 * Finds orphaned term_ids (term_taxonomy exists but term row doesn't) where term_taxonomy row exists but term row doesn't.
+	 *
+	 * @param string $table_prefix Table prefix (e.g., 'cdiff_').
+	 *
+	 * @return array Orphaned term_ids.
+	 */
+	public function get_orphaned_term_ids( string $table_prefix ): array {
+		// phpcs:disable -- WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$results = $this->wpdb->get_col(
+			"SELECT tt.term_id
+			FROM {$table_prefix}term_taxonomy tt
+			LEFT JOIN {$table_prefix}terms t ON tt.term_id = t.term_id
+			WHERE t.term_id IS NULL"
+		);
+		// phpcs:ensable
+
+		return array_map( 'intval', $results ?? [] );
 	}
 
 	/**

--- a/src/Logic/ContentDiffLogic.php
+++ b/src/Logic/ContentDiffLogic.php
@@ -948,7 +948,12 @@ class ContentDiffLogic {
 						if ( ! empty( $taxonomies ) && ! in_array( $term_taxonomy['taxonomy'], $taxonomies, true ) ) {
 							continue;
 						}
-						$term_id                       = (int) $term_taxonomy['term_id'];
+						$term_id = (int) $term_taxonomy['term_id'];
+						// Skip orphaned terms on live (handle cases where term_taxonomy exists but term row doesn't).
+						$term_row = $this->select_term_row( $live_table_prefix, $term_id );
+						if ( ! $term_row ) {
+							continue;
+						}
 						$live_term_ids[]               = $term_id;
 						$live_term_details[ $term_id ] = [
 							'taxonomy' => $term_taxonomy['taxonomy'],

--- a/src/Logic/ContentDiffLogic.php
+++ b/src/Logic/ContentDiffLogic.php
@@ -2060,7 +2060,7 @@ class ContentDiffLogic {
 			LEFT JOIN {$table_prefix}terms t ON tt.term_id = t.term_id
 			WHERE t.term_id IS NULL"
 		);
-		// phpcs:ensable
+		// phpcs:enable
 
 		return array_map( 'intval', $results ?? [] );
 	}

--- a/src/Logic/DataImporter.php
+++ b/src/Logic/DataImporter.php
@@ -447,7 +447,7 @@ class DataImporter {
 		// Validate live term row, it could be missing or invalid.
 		if ( is_null( $live_term_row ) ) {
 			Logger::instance()->log_brief_and_verbose(
-				LogLevel::ERROR,
+				LogLevel::WARNING,
 				'import_single_term_relationship: term_id does not exist in live DB term table, skipping',
 				[
 					'id_old'                 => $id_old,

--- a/tests/Integration/CmdMigrateLiveContentMigrationDataConsistencyStandardTest.php
+++ b/tests/Integration/CmdMigrateLiveContentMigrationDataConsistencyStandardTest.php
@@ -1479,8 +1479,10 @@ class CmdMigrateLiveContentMigrationDataConsistencyStandardTest extends Integrat
 		$this->assertNotNull( $local_post_id, 'Post should be imported.' );
 
 		// Verify the category term was attributed (has oldid meta).
-		$local_cat_term_id = $this->logic->get_current_term_id_by_old_id( 4510, $this->source_hostname );
-		$this->assertNotNull( $local_cat_term_id, 'Category term should be attributed.' );
+		$local_cat_term = get_term_by( 'slug', 'attributed-cat', 'category' );
+		$this->assertNotFalse( $local_cat_term, 'Category term should exist on local.' );
+		$local_cat_old_id = get_term_meta( $local_cat_term->term_id, $this->get_old_id_meta_key(), true );
+		$this->assertEquals( 4510, (int) $local_cat_old_id, 'Category term should be attributed with correct old_id.' );
 
 		// Verify the ef_editorial_meta term was NOT imported (taxonomy not in DEFAULT_TAXONOMIES).
 		$ef_term_on_local = get_term_by( 'slug', 'in-progress', 'ef_editorial_meta' );
@@ -1536,8 +1538,10 @@ class CmdMigrateLiveContentMigrationDataConsistencyStandardTest extends Integrat
 		$this->assertNotNull( $local_post_id, 'Post should be imported.' );
 
 		// Verify category term was attributed.
-		$local_cat_term_id = $this->logic->get_current_term_id_by_old_id( 4520, $this->source_hostname );
-		$this->assertNotNull( $local_cat_term_id, 'Category term should be attributed.' );
+		$local_cat_term = get_term_by( 'slug', 'same-cat', 'category' );
+		$this->assertNotFalse( $local_cat_term, 'Category term should exist on local.' );
+		$local_cat_old_id = get_term_meta( $local_cat_term->term_id, $this->get_old_id_meta_key(), true );
+		$this->assertEquals( 4520, (int) $local_cat_old_id, 'Category term should be attributed with correct old_id.' );
 
 		// Verify post_tag was NOT imported (not in custom-taxonomies-csv).
 		$tag_on_local = get_term_by( 'slug', 'original-tag', 'post_tag' );
@@ -1590,8 +1594,11 @@ class CmdMigrateLiveContentMigrationDataConsistencyStandardTest extends Integrat
 		$this->assertNotNull( $local_post_id, 'Post should be imported.' );
 
 		// Verify category term was attributed.
-		$local_cat_term_id = $this->logic->get_current_term_id_by_old_id( 4530, $this->source_hostname );
-		$this->assertNotNull( $local_cat_term_id, 'Category term should be attributed.' );
+		$local_cat_term = get_term_by( 'slug', 'live-category', 'category' );
+		$this->assertNotFalse( $local_cat_term, 'Category term should exist on local.' );
+		$local_cat_term_id = $local_cat_term->term_id;
+		$local_cat_old_id  = get_term_meta( $local_cat_term_id, $this->get_old_id_meta_key(), true );
+		$this->assertEquals( 4530, (int) $local_cat_old_id, 'Category term should be attributed with correct old_id.' );
 
 		// Now add a LOCAL-ONLY category to the post (simulating editorial work on staging).
 		$local_only_term    = wp_insert_term( 'Local Only Category', 'category' );

--- a/tests/Integration/CmdMigrateLiveContentMigrationDataConsistencyStandardTest.php
+++ b/tests/Integration/CmdMigrateLiveContentMigrationDataConsistencyStandardTest.php
@@ -2846,4 +2846,57 @@ class CmdMigrateLiveContentMigrationDataConsistencyStandardTest extends Integrat
 		$deleted_map = $this->run_state->get_deleted_modified_ids_map();
 		$this->assertArrayHasKey( 28001, $deleted_map, 'Reimported modified post should be in deleted_modified_ids.' );
 	}
+
+	/**
+	 * Tests that orphaned term relationships don't trigger false modified detection.
+	 *
+	 * Scenario: Live site has corrupt data where term_taxonomy row exists but
+	 * the corresponding term row in the terms table does not (orphaned data).
+	 * This should be gracefully skipped, not cause false positives.
+	 *
+	 * @group migration-data-consistency-standard
+	 */
+	public function test_should_not_detect_modified_when_live_has_orphaned_term(): void {
+		global $wpdb;
+
+		// Create a live post with a valid category term.
+		$post = $this->create_post_fixture(
+			[
+				'ID'            => 4508,
+				'post_modified' => '2024-01-01 10:00:00',
+			]
+		);
+		$wpdb->insert( $this->live_table_prefix . 'posts', $post ); // phpcs:ignore
+
+		// Insert valid category term.
+		$valid_term_id = 4580;
+		$wpdb->insert( $this->live_table_prefix . 'terms', [ 'term_id' => $valid_term_id, 'name' => 'Valid Category', 'slug' => 'valid-category' ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => $valid_term_id, 'term_id' => $valid_term_id, 'taxonomy' => 'category', 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_relationships', [ 'object_id' => 4508, 'term_taxonomy_id' => $valid_term_id ] ); // phpcs:ignore
+
+		// Insert ORPHANED term relationship: term_taxonomy exists, but NO term row.
+		$orphan_term_id     = 4599;
+		$orphan_term_tax_id = 4598;
+		$wpdb->insert( $this->live_table_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => $orphan_term_tax_id, 'term_id' => $orphan_term_id, 'taxonomy' => 'category', 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_relationships', [ 'object_id' => 4508, 'term_taxonomy_id' => $orphan_term_tax_id ] ); // phpcs:ignore
+		// NOTE: No insert into cdiff_terms for $orphan_term_id - this is the orphan!
+
+		$this->run_search_command();
+		$this->run_migrate_command();
+
+		// Verify post was imported with valid category.
+		$local_post_id = $this->logic->get_current_post_id_by_old_id( 4508, $this->source_hostname );
+		$this->assertNotNull( $local_post_id, 'Post should be imported.' );
+
+		// Fresh run-state for second migration cycle.
+		$this->cleanup_temp_dir( $this->temp_data_dir );
+		$this->run_state = new \Newspack\ContentDiffMigrator\Logic\RunState( $this->temp_data_dir . '/run-state' );
+		$this->command->set_run_state( $this->run_state );
+
+		$this->run_search_command();
+
+		// Post should NOT be flagged as modified due to orphaned term.
+		$modified_ids = $this->run_state->get_modified_ids_map();
+		$this->assertArrayNotHasKey( 4508, $modified_ids, 'Post should NOT be detected as modified due to orphaned term relationship on live.' );
+	}
 }

--- a/tests/Integration/CmdMigrateLiveContentMigrationDataConsistencyStandardTest.php
+++ b/tests/Integration/CmdMigrateLiveContentMigrationDataConsistencyStandardTest.php
@@ -1210,6 +1210,39 @@ class CmdMigrateLiveContentMigrationDataConsistencyStandardTest extends Integrat
 	}
 
 	/**
+	 * Tests that posts are detected as modified when comment_count changes (Check #3).
+	 *
+	 * @group migration-data-consistency-standard
+	 */
+	public function test_should_filter_modified_posts_when_comment_count_changed(): void {
+		global $wpdb;
+
+		$post = $this->create_post_fixture(
+			[
+				'ID'            => 4502,
+				'comment_count' => 3,
+			]
+		);
+		$wpdb->insert( $this->live_table_prefix . 'posts', $post ); // phpcs:ignore
+
+		$this->run_search_command();
+		$this->run_migrate_command();
+
+		// Change comment_count in live (simulates comments added/removed on live).
+		$wpdb->update( $this->live_table_prefix . 'posts', [ 'comment_count' => 5 ], [ 'ID' => 4502 ] ); // phpcs:ignore
+
+		// Fresh run-state for new migration cycle.
+		$this->cleanup_temp_dir( $this->temp_data_dir );
+		$this->run_state = new \Newspack\ContentDiffMigrator\Logic\RunState( $this->temp_data_dir . '/run-state' );
+		$this->command->set_run_state( $this->run_state );
+
+		$this->run_search_command();
+
+		$modified_ids = $this->run_state->get_modified_ids_map();
+		$this->assertArrayHasKey( 4502, $modified_ids, 'Post should be detected as modified when comment_count changes.' );
+	}
+
+	/**
 	 * Tests that posts are detected as modified when post_author changes.
 	 *
 	 * @group migration-data-consistency-standard
@@ -1402,6 +1435,371 @@ class CmdMigrateLiveContentMigrationDataConsistencyStandardTest extends Integrat
 
 		$modified_ids = $this->run_state->get_modified_ids_map();
 		$this->assertArrayHasKey( 4006, $modified_ids, 'Post should be detected as modified when a term is removed on live.' );
+	}
+
+	/**
+	 * Tests that terms in non-attributed taxonomies don't trigger false positive modified detection.
+	 *
+	 * Scenario: Live post has terms in ef_editorial_meta (Edit Flow operational metadata).
+	 * Since ef_editorial_meta is NOT in DEFAULT_TAXONOMIES, these terms are:
+	 * 1. Not imported during migrate (filtered by $taxonomies_to_migrate)
+	 * 2. Not compared during search (filtered by $taxonomies param in filter_modified_live_ids)
+	 *
+	 * Without the fix in filter_modified_live_ids, Check #6 would compare ALL taxonomies,
+	 * finding ef_editorial_meta terms on live but not on local, causing false positives.
+	 *
+	 * @group migration-data-consistency-standard
+	 */
+	public function test_should_not_detect_modified_when_taxonomy_not_in_attribution_list(): void {
+		global $wpdb;
+
+		// Register a custom taxonomy that is NOT in DEFAULT_TAXONOMIES.
+		register_taxonomy( 'ef_editorial_meta', 'post' );
+
+		// Create post in live tables.
+		$post = $this->create_post_fixture( [ 'ID' => 4501 ] );
+		$wpdb->insert( $this->live_table_prefix . 'posts', $post ); // phpcs:ignore
+
+		// Create a category term (IS in DEFAULT_TAXONOMIES) - this will be imported and attributed.
+		$wpdb->insert( $this->live_table_prefix . 'terms', [ 'term_id' => 4510, 'name' => 'Attributed Cat', 'slug' => 'attributed-cat', 'term_group' => 0 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => 4510, 'term_id' => 4510, 'taxonomy' => 'category', 'description' => '', 'parent' => 0, 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_relationships', [ 'object_id' => 4501, 'term_taxonomy_id' => 4510 ] ); // phpcs:ignore
+
+		// Create an ef_editorial_meta term (NOT in DEFAULT_TAXONOMIES) - this will NOT be imported.
+		$wpdb->insert( $this->live_table_prefix . 'terms', [ 'term_id' => 4511, 'name' => 'In Progress', 'slug' => 'in-progress', 'term_group' => 0 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => 4511, 'term_id' => 4511, 'taxonomy' => 'ef_editorial_meta', 'description' => '', 'parent' => 0, 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_relationships', [ 'object_id' => 4501, 'term_taxonomy_id' => 4511 ] ); // phpcs:ignore
+
+		// First migration: import the post with its terms.
+		$this->run_search_command();
+		$this->run_migrate_command();
+
+		// Verify post was imported.
+		$local_post_id = $this->logic->get_current_post_id_by_old_id( 4501, $this->source_hostname );
+		$this->assertNotNull( $local_post_id, 'Post should be imported.' );
+
+		// Verify the category term was attributed (has oldid meta).
+		$local_cat_term_id = $this->logic->get_current_term_id_by_old_id( 4510, $this->source_hostname );
+		$this->assertNotNull( $local_cat_term_id, 'Category term should be attributed.' );
+
+		// Verify the ef_editorial_meta term was NOT imported (taxonomy not in DEFAULT_TAXONOMIES).
+		$ef_term_on_local = get_term_by( 'slug', 'in-progress', 'ef_editorial_meta' );
+		$this->assertFalse( $ef_term_on_local, 'ef_editorial_meta term should NOT exist on local (not imported).' );
+
+		// Fresh run-state for new migration cycle.
+		$this->cleanup_temp_dir( $this->temp_data_dir );
+		$this->run_state = new \Newspack\ContentDiffMigrator\Logic\RunState( $this->temp_data_dir . '/run-state' );
+		$this->command->set_run_state( $this->run_state );
+
+		// Second migration cycle: run search again.
+		// BUG: Without the fix, Check #6 would find ef_editorial_meta term (4511) on live
+		// but not on local, flagging the post as modified.
+		// FIX: Check #6 now filters to only compare DEFAULT_TAXONOMIES, skipping ef_editorial_meta.
+		$this->run_search_command();
+
+		$modified_ids = $this->run_state->get_modified_ids_map();
+		$this->assertArrayNotHasKey( 4501, $modified_ids, 'Post should NOT be detected as modified when only non-DEFAULT_TAXONOMIES terms differ.' );
+	}
+
+	/**
+	 * Tests that only taxonomies in --custom-taxonomies-csv are compared for modifications.
+	 *
+	 * Scenario: Post has terms in both 'category' and 'post_tag'.
+	 * Run with --custom-taxonomies-csv=category (excludes post_tag).
+	 * Changes in post_tag should NOT trigger modified detection.
+	 *
+	 * @group migration-data-consistency-standard
+	 */
+	public function test_should_detect_modified_only_for_taxonomies_in_custom_taxonomies_csv(): void {
+		global $wpdb;
+
+		// Create post with category and post_tag terms.
+		$post = $this->create_post_fixture( [ 'ID' => 4508 ] );
+		$wpdb->insert( $this->live_table_prefix . 'posts', $post ); // phpcs:ignore
+
+		// Create category term.
+		$wpdb->insert( $this->live_table_prefix . 'terms', [ 'term_id' => 4520, 'name' => 'Same Cat', 'slug' => 'same-cat', 'term_group' => 0 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => 4520, 'term_id' => 4520, 'taxonomy' => 'category', 'description' => '', 'parent' => 0, 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_relationships', [ 'object_id' => 4508, 'term_taxonomy_id' => 4520 ] ); // phpcs:ignore
+
+		// Create post_tag term.
+		$wpdb->insert( $this->live_table_prefix . 'terms', [ 'term_id' => 4521, 'name' => 'Original Tag', 'slug' => 'original-tag', 'term_group' => 0 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => 4521, 'term_id' => 4521, 'taxonomy' => 'post_tag', 'description' => '', 'parent' => 0, 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_relationships', [ 'object_id' => 4508, 'term_taxonomy_id' => 4521 ] ); // phpcs:ignore
+
+		// First migration with only 'category' in custom-taxonomies-csv (excludes post_tag).
+		$this->run_search_command( [ 'custom-taxonomies-csv' => 'category' ] );
+		$this->run_migrate_command( [ 'custom-taxonomies-csv' => 'category' ] );
+
+		// Verify post was imported.
+		$local_post_id = $this->logic->get_current_post_id_by_old_id( 4508, $this->source_hostname );
+		$this->assertNotNull( $local_post_id, 'Post should be imported.' );
+
+		// Verify category term was attributed.
+		$local_cat_term_id = $this->logic->get_current_term_id_by_old_id( 4520, $this->source_hostname );
+		$this->assertNotNull( $local_cat_term_id, 'Category term should be attributed.' );
+
+		// Verify post_tag was NOT imported (not in custom-taxonomies-csv).
+		$tag_on_local = get_term_by( 'slug', 'original-tag', 'post_tag' );
+		$this->assertFalse( $tag_on_local, 'post_tag term should NOT be imported when not in custom-taxonomies-csv.' );
+
+		// Now add a NEW post_tag on live (simulating tag change).
+		$wpdb->insert( $this->live_table_prefix . 'terms', [ 'term_id' => 4522, 'name' => 'New Tag', 'slug' => 'new-tag', 'term_group' => 0 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => 4522, 'term_id' => 4522, 'taxonomy' => 'post_tag', 'description' => '', 'parent' => 0, 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_relationships', [ 'object_id' => 4508, 'term_taxonomy_id' => 4522 ] ); // phpcs:ignore
+
+		// Fresh run-state for new migration cycle.
+		$this->cleanup_temp_dir( $this->temp_data_dir );
+		$this->run_state = new \Newspack\ContentDiffMigrator\Logic\RunState( $this->temp_data_dir . '/run-state' );
+		$this->command->set_run_state( $this->run_state );
+
+		// Run search again with same custom-taxonomies-csv.
+		$this->run_search_command( [ 'custom-taxonomies-csv' => 'category' ] );
+
+		$modified_ids = $this->run_state->get_modified_ids_map();
+		$this->assertArrayNotHasKey( 4508, $modified_ids, 'Post should NOT be detected as modified when only excluded taxonomy (post_tag) changes.' );
+	}
+
+	/**
+	 * Tests that locally-added terms (no attribution meta) don't cause false positives.
+	 *
+	 * Scenario: Post is imported with category term. Later, a new category is added locally
+	 * (no attribution meta because it was created locally, not migrated).
+	 * The local-only term should not cause the post to be flagged as modified.
+	 *
+	 * @group migration-data-consistency-standard
+	 */
+	public function test_should_not_flag_modified_when_local_term_has_no_attribution_meta(): void {
+		global $wpdb;
+
+		// Create post with one category term.
+		$post = $this->create_post_fixture( [ 'ID' => 4509 ] );
+		$wpdb->insert( $this->live_table_prefix . 'posts', $post ); // phpcs:ignore
+
+		// Create category term on live.
+		$wpdb->insert( $this->live_table_prefix . 'terms', [ 'term_id' => 4530, 'name' => 'Live Category', 'slug' => 'live-category', 'term_group' => 0 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => 4530, 'term_id' => 4530, 'taxonomy' => 'category', 'description' => '', 'parent' => 0, 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_relationships', [ 'object_id' => 4509, 'term_taxonomy_id' => 4530 ] ); // phpcs:ignore
+
+		// First migration.
+		$this->run_search_command();
+		$this->run_migrate_command();
+
+		// Verify post was imported.
+		$local_post_id = $this->logic->get_current_post_id_by_old_id( 4509, $this->source_hostname );
+		$this->assertNotNull( $local_post_id, 'Post should be imported.' );
+
+		// Verify category term was attributed.
+		$local_cat_term_id = $this->logic->get_current_term_id_by_old_id( 4530, $this->source_hostname );
+		$this->assertNotNull( $local_cat_term_id, 'Category term should be attributed.' );
+
+		// Now add a LOCAL-ONLY category to the post (simulating editorial work on staging).
+		$local_only_term    = wp_insert_term( 'Local Only Category', 'category' );
+		$local_only_term_id = $local_only_term['term_id'];
+		wp_set_object_terms( $local_post_id, [ $local_cat_term_id, $local_only_term_id ], 'category' );
+
+		// Verify local-only term has NO attribution meta.
+		$local_only_meta = get_term_meta( $local_only_term_id, $this->get_old_id_meta_key(), true );
+		$this->assertEmpty( $local_only_meta, 'Local-only term should NOT have attribution meta.' );
+
+		// Fresh run-state for new migration cycle.
+		$this->cleanup_temp_dir( $this->temp_data_dir );
+		$this->run_state = new \Newspack\ContentDiffMigrator\Logic\RunState( $this->temp_data_dir . '/run-state' );
+		$this->command->set_run_state( $this->run_state );
+
+		// Run search again.
+		$this->run_search_command();
+
+		// Post should NOT be flagged as modified.
+		// The local-only term doesn't exist on live, but that's expected (local addition).
+		// Only LIVE terms missing on LOCAL should trigger modified (and only for attributed taxonomies).
+		$modified_ids = $this->run_state->get_modified_ids_map();
+		$this->assertArrayNotHasKey( 4509, $modified_ids, 'Post should NOT be detected as modified when local has additional non-attributed terms.' );
+	}
+
+	/**
+	 * Tests that postmeta changes alone do NOT trigger modified detection.
+	 *
+	 * Per MDCS: postmeta changes are only detected indirectly via post_modified bump.
+	 * If post_modified hasn't changed, postmeta-only changes should not flag the post.
+	 *
+	 * @group migration-data-consistency-standard
+	 */
+	public function test_should_not_detect_modified_when_only_postmeta_changed(): void {
+		global $wpdb;
+
+		$post = $this->create_post_fixture(
+			[
+				'ID'            => 4503,
+				'post_modified' => '2024-01-01 10:00:00',
+			]
+		);
+		$wpdb->insert( $this->live_table_prefix . 'posts', $post ); // phpcs:ignore
+
+		// Add custom postmeta.
+		$wpdb->insert( $this->live_table_prefix . 'postmeta', [ 'meta_id' => 45031, 'post_id' => 4503, 'meta_key' => 'custom_key', 'meta_value' => 'original_value' ] ); // phpcs:ignore
+
+		$this->run_search_command();
+		$this->run_migrate_command();
+
+		// Change ONLY postmeta in live (without updating post_modified).
+		$wpdb->update( $this->live_table_prefix . 'postmeta', [ 'meta_value' => 'changed_value' ], [ 'post_id' => 4503, 'meta_key' => 'custom_key' ] ); // phpcs:ignore
+
+		// Fresh run-state for new migration cycle.
+		$this->cleanup_temp_dir( $this->temp_data_dir );
+		$this->run_state = new \Newspack\ContentDiffMigrator\Logic\RunState( $this->temp_data_dir . '/run-state' );
+		$this->command->set_run_state( $this->run_state );
+
+		$this->run_search_command();
+
+		$modified_ids = $this->run_state->get_modified_ids_map();
+		$this->assertArrayNotHasKey( 4503, $modified_ids, 'Post should NOT be detected as modified when only postmeta changes (without post_modified bump).' );
+	}
+
+	/**
+	 * Tests that comment content changes alone do NOT trigger modified detection.
+	 *
+	 * Per MDCS: comment changes are only detected via comment_count changes.
+	 * If comment_count is the same, comment content/author changes should not flag the post.
+	 *
+	 * @group migration-data-consistency-standard
+	 */
+	public function test_should_not_detect_modified_when_only_comments_changed(): void {
+		global $wpdb;
+
+		$post = $this->create_post_fixture(
+			[
+				'ID'            => 4504,
+				'comment_count' => 1,
+			]
+		);
+		$wpdb->insert( $this->live_table_prefix . 'posts', $post ); // phpcs:ignore
+
+		// Add a comment.
+		$wpdb->insert( $this->live_table_prefix . 'comments', [ 'comment_ID' => 45041, 'comment_post_ID' => 4504, 'comment_content' => 'Original comment', 'comment_approved' => '1', 'comment_author' => 'Test', 'comment_date' => '2024-01-01 10:00:00', 'comment_date_gmt' => '2024-01-01 10:00:00' ] ); // phpcs:ignore
+
+		$this->run_search_command();
+		$this->run_migrate_command();
+
+		// Change comment content in live (but keep same comment_count).
+		$wpdb->update( $this->live_table_prefix . 'comments', [ 'comment_content' => 'Modified comment text' ], [ 'comment_ID' => 45041 ] ); // phpcs:ignore
+
+		// Fresh run-state for new migration cycle.
+		$this->cleanup_temp_dir( $this->temp_data_dir );
+		$this->run_state = new \Newspack\ContentDiffMigrator\Logic\RunState( $this->temp_data_dir . '/run-state' );
+		$this->command->set_run_state( $this->run_state );
+
+		$this->run_search_command();
+
+		$modified_ids = $this->run_state->get_modified_ids_map();
+		$this->assertArrayNotHasKey( 4504, $modified_ids, 'Post should NOT be detected as modified when only comment content changes (same comment_count).' );
+	}
+
+	/**
+	 * Tests that attachments are excluded from post-style modification checks.
+	 *
+	 * Per MDCS: Attachments have field-by-field updates, not full reimport.
+	 * Changes to attachment post_status should NOT trigger modified detection.
+	 *
+	 * @group migration-data-consistency-standard
+	 */
+	public function test_should_not_detect_attachments_as_modified_per_mdcs(): void {
+		global $wpdb;
+
+		$attachment = $this->create_post_fixture(
+			[
+				'ID'          => 4505,
+				'post_type'   => 'attachment',
+				'post_status' => 'inherit',
+			]
+		);
+		$wpdb->insert( $this->live_table_prefix . 'posts', $attachment ); // phpcs:ignore
+
+		$this->run_search_command( [ 'post-types-csv' => 'attachment' ] );
+		$this->run_migrate_command();
+
+		// Change attachment post_status (would trigger Check #2 for regular posts).
+		$wpdb->update( $this->live_table_prefix . 'posts', [ 'post_status' => 'private' ], [ 'ID' => 4505 ] ); // phpcs:ignore
+
+		// Fresh run-state for new migration cycle.
+		$this->cleanup_temp_dir( $this->temp_data_dir );
+		$this->run_state = new \Newspack\ContentDiffMigrator\Logic\RunState( $this->temp_data_dir . '/run-state' );
+		$this->command->set_run_state( $this->run_state );
+
+		$this->run_search_command( [ 'post-types-csv' => 'attachment' ] );
+
+		$modified_ids = $this->run_state->get_modified_ids_map();
+		$this->assertArrayNotHasKey( 4505, $modified_ids, 'Attachment should NOT be detected as modified (MDCS excludes attachments from post-style checks).' );
+	}
+
+	/**
+	 * Tests that reimporting a modified post updates block attachment IDs.
+	 *
+	 * When a post is reimported, Gutenberg blocks containing attachment IDs
+	 * (like wp:image) should have their IDs remapped to the new local attachment IDs.
+	 *
+	 * @group migration-data-consistency-standard
+	 */
+	public function test_reimport_should_update_block_attachment_ids(): void {
+		global $wpdb;
+
+		// Create an attachment on live.
+		$attachment = $this->create_post_fixture(
+			[
+				'ID'          => 4506,
+				'post_type'   => 'attachment',
+				'post_status' => 'inherit',
+			]
+		);
+		$wpdb->insert( $this->live_table_prefix . 'posts', $attachment ); // phpcs:ignore
+
+		// Create a post with wp:image block referencing the attachment.
+		$post = $this->create_post_fixture(
+			[
+				'ID'            => 4507,
+				'post_content'  => '<!-- wp:image {"id":4506} --><figure class="wp-block-image"><img src="http://example.com/image.jpg" alt="" class="wp-image-4506"/></figure><!-- /wp:image -->',
+				'post_modified' => '2024-01-01 10:00:00',
+			]
+		);
+		$wpdb->insert( $this->live_table_prefix . 'posts', $post ); // phpcs:ignore
+
+		$this->run_search_command( [ 'post-types-csv' => 'post,attachment' ] );
+		$this->run_migrate_command();
+
+		// Get the new local attachment ID.
+		$local_attachment_id = $this->logic->get_current_post_id_by_old_id( 4506, $this->source_hostname );
+		$this->assertNotNull( $local_attachment_id, 'Attachment should be imported.' );
+
+		// Get the local post and verify block IDs were remapped.
+		$local_post_id = $this->logic->get_current_post_id_by_old_id( 4507, $this->source_hostname );
+		$this->assertNotNull( $local_post_id, 'Post should be imported.' );
+
+		$local_post = get_post( $local_post_id );
+		$this->assertStringContainsString( '"id":' . $local_attachment_id, $local_post->post_content, 'Block attachment ID should be remapped to local ID.' );
+		$this->assertStringContainsString( 'wp-image-' . $local_attachment_id, $local_post->post_content, 'Block CSS class should reference local attachment ID.' );
+
+		// Now modify the post on live to trigger reimport.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->update(
+			$this->live_table_prefix . 'posts',
+			[
+				'post_modified'     => '2024-06-01 10:00:00',
+				'post_modified_gmt' => '2024-06-01 10:00:00',
+			],
+			[ 'ID' => 4507 ]
+		);
+
+		// Fresh run-state for new migration cycle.
+		$this->cleanup_temp_dir( $this->temp_data_dir );
+		$this->run_state = new \Newspack\ContentDiffMigrator\Logic\RunState( $this->temp_data_dir . '/run-state' );
+		$this->command->set_run_state( $this->run_state );
+
+		$this->run_search_command( [ 'post-types-csv' => 'post,attachment' ] );
+		$this->run_migrate_command();
+
+		// Verify block IDs are still correctly mapped after reimport.
+		$reimported_post = get_post( $local_post_id );
+		$this->assertStringContainsString( '"id":' . $local_attachment_id, $reimported_post->post_content, 'Block attachment ID should remain correctly mapped after reimport.' );
 	}
 
 	/**

--- a/tests/Integration/CmdMigrateLiveContentPostsModifiedTest.php
+++ b/tests/Integration/CmdMigrateLiveContentPostsModifiedTest.php
@@ -386,6 +386,90 @@ class CmdMigrateLiveContentPostsModifiedTest extends IntegrationTestCase {
 	}
 
 	/**
+	 * Tests that when a comment has multiple commentmeta entries and one is deleted on live,
+	 * only the remaining metas exist after reimport.
+	 *
+	 * @group posts-modified
+	 */
+	public function test_should_remove_one_commentmeta_when_comment_has_multiple_metas_and_one_deleted(): void {
+		global $wpdb;
+
+		$post = $this->create_post_fixture(
+			[
+				'ID'            => 8003,
+				'post_modified' => '2024-01-01 10:00:00',
+				'comment_count' => 1,
+			]
+		);
+		$wpdb->insert( $this->live_table_prefix . 'posts', $post ); // phpcs:ignore
+
+		// Create a comment with three metas.
+		$comment = [
+			'comment_ID'           => 8301,
+			'comment_post_ID'      => 8003,
+			'comment_author'       => 'Commenter',
+			'comment_author_email' => 'commenter@example.com',
+			'comment_author_url'   => '',
+			'comment_author_IP'    => '127.0.0.1',
+			'comment_date'         => '2024-01-01 12:00:00',
+			'comment_date_gmt'     => '2024-01-01 12:00:00',
+			'comment_content'      => 'Test comment with metas',
+			'comment_karma'        => 0,
+			'comment_approved'     => '1',
+			'comment_agent'        => '',
+			'comment_type'         => 'comment',
+			'comment_parent'       => 0,
+			'user_id'              => 0,
+		];
+		$wpdb->insert( $this->live_table_prefix . 'comments', $comment ); // phpcs:ignore
+
+		// Add three commentmeta entries.
+		$wpdb->insert( $this->live_table_prefix . 'commentmeta', [ 'meta_id' => 8401, 'comment_id' => 8301, 'meta_key' => 'cmeta_alpha', 'meta_value' => 'Alpha Value' ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'commentmeta', [ 'meta_id' => 8402, 'comment_id' => 8301, 'meta_key' => 'cmeta_beta', 'meta_value' => 'Beta Value' ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'commentmeta', [ 'meta_id' => 8403, 'comment_id' => 8301, 'meta_key' => 'cmeta_gamma', 'meta_value' => 'Gamma Value' ] ); // phpcs:ignore
+
+		$this->run_search_command();
+		$this->run_migrate_command();
+
+		$new_post_id = $this->logic->get_current_post_id_by_old_id( 8003, $this->source_hostname );
+		$comments    = get_comments( [ 'post_id' => $new_post_id ] );
+		$this->assertCount( 1, $comments, 'Post should have 1 comment after initial import.' );
+
+		$new_comment_id = $comments[0]->comment_ID;
+		$this->assertEquals( 'Alpha Value', get_comment_meta( $new_comment_id, 'cmeta_alpha', true ) );
+		$this->assertEquals( 'Beta Value', get_comment_meta( $new_comment_id, 'cmeta_beta', true ) );
+		$this->assertEquals( 'Gamma Value', get_comment_meta( $new_comment_id, 'cmeta_gamma', true ) );
+
+		// Delete cmeta_beta on live and modify post.
+		$wpdb->delete( $this->live_table_prefix . 'commentmeta', [ 'meta_id' => 8402 ] ); // phpcs:ignore
+		$wpdb->update( // phpcs:ignore
+			$this->live_table_prefix . 'posts',
+			[
+				'post_modified'     => '2024-06-01 10:00:00',
+				'post_modified_gmt' => '2024-06-01 10:00:00',
+			],
+			[ 'ID' => 8003 ]
+		);
+
+		// Fresh run-state.
+		$this->cleanup_temp_dir( $this->temp_data_dir );
+		$this->run_state = new \Newspack\ContentDiffMigrator\Logic\RunState( $this->temp_data_dir . '/run-state' );
+		$this->command->set_run_state( $this->run_state );
+
+		$this->run_search_command();
+		$this->run_migrate_command();
+
+		$reimported_post_id = $this->logic->get_current_post_id_by_old_id( 8003, $this->source_hostname );
+		$comments_after     = get_comments( [ 'post_id' => $reimported_post_id ] );
+		$this->assertCount( 1, $comments_after, 'Post should still have 1 comment after reimport.' );
+
+		$reimported_comment_id = $comments_after[0]->comment_ID;
+		$this->assertEquals( 'Alpha Value', get_comment_meta( $reimported_comment_id, 'cmeta_alpha', true ), 'Commentmeta Alpha should remain.' );
+		$this->assertEmpty( get_comment_meta( $reimported_comment_id, 'cmeta_beta', true ), 'Commentmeta Beta should be removed.' );
+		$this->assertEquals( 'Gamma Value', get_comment_meta( $reimported_comment_id, 'cmeta_gamma', true ), 'Commentmeta Gamma should remain.' );
+	}
+
+	/**
 	 * Tests that when a post has multiple postmeta entries and one is deleted on live,
 	 * only the remaining metas exist after reimport.
 	 *
@@ -439,5 +523,144 @@ class CmdMigrateLiveContentPostsModifiedTest extends IntegrationTestCase {
 		$this->assertEquals( 'Alpha Value', get_post_meta( $reimported_post_id, 'meta_alpha', true ), 'Meta Alpha should remain.' );
 		$this->assertEmpty( get_post_meta( $reimported_post_id, 'meta_beta', true ), 'Meta Beta should be removed.' );
 		$this->assertEquals( 'Gamma Value', get_post_meta( $reimported_post_id, 'meta_gamma', true ), 'Meta Gamma should remain.' );
+	}
+
+	/**
+	 * Tests that when a post has multiple term relationships and one is removed on live,
+	 * only the remaining terms exist after reimport.
+	 *
+	 * @group posts-modified
+	 */
+	public function test_should_remove_one_term_relationship_when_post_has_multiple_terms_and_one_removed(): void {
+		global $wpdb;
+
+		$post = $this->create_post_fixture(
+			[
+				'ID'            => 16001,
+				'post_modified' => '2024-01-01 10:00:00',
+			]
+		);
+		$wpdb->insert( $this->live_table_prefix . 'posts', $post ); // phpcs:ignore
+
+		// Create three categories and assign to post.
+		$wpdb->insert( $this->live_table_prefix . 'terms', [ 'term_id' => 16101, 'name' => 'Term Alpha', 'slug' => 'term-alpha', 'term_group' => 0 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => 16101, 'term_id' => 16101, 'taxonomy' => 'category', 'description' => '', 'parent' => 0, 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_relationships', [ 'object_id' => 16001, 'term_taxonomy_id' => 16101, 'term_order' => 0 ] ); // phpcs:ignore
+
+		$wpdb->insert( $this->live_table_prefix . 'terms', [ 'term_id' => 16102, 'name' => 'Term Beta', 'slug' => 'term-beta', 'term_group' => 0 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => 16102, 'term_id' => 16102, 'taxonomy' => 'category', 'description' => '', 'parent' => 0, 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_relationships', [ 'object_id' => 16001, 'term_taxonomy_id' => 16102, 'term_order' => 0 ] ); // phpcs:ignore
+
+		$wpdb->insert( $this->live_table_prefix . 'terms', [ 'term_id' => 16103, 'name' => 'Term Gamma', 'slug' => 'term-gamma', 'term_group' => 0 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => 16103, 'term_id' => 16103, 'taxonomy' => 'category', 'description' => '', 'parent' => 0, 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $this->live_table_prefix . 'term_relationships', [ 'object_id' => 16001, 'term_taxonomy_id' => 16103, 'term_order' => 0 ] ); // phpcs:ignore
+
+		$this->run_search_command();
+		$this->run_migrate_command();
+
+		$new_post_id = $this->logic->get_current_post_id_by_old_id( 16001, $this->source_hostname );
+		$terms       = wp_get_post_terms( $new_post_id, 'category', [ 'fields' => 'names' ] );
+		$this->assertCount( 3, $terms, 'Post should have 3 terms after initial import.' );
+		$this->assertContains( 'Term Alpha', $terms );
+		$this->assertContains( 'Term Beta', $terms );
+		$this->assertContains( 'Term Gamma', $terms );
+
+		// Remove Term Beta relationship on live and modify post.
+		$wpdb->delete( $this->live_table_prefix . 'term_relationships', [ 'object_id' => 16001, 'term_taxonomy_id' => 16102 ] ); // phpcs:ignore
+		$wpdb->update( // phpcs:ignore
+			$this->live_table_prefix . 'posts',
+			[
+				'post_modified'     => '2024-06-01 10:00:00',
+				'post_modified_gmt' => '2024-06-01 10:00:00',
+			],
+			[ 'ID' => 16001 ]
+		);
+
+		// Fresh run-state.
+		$this->cleanup_temp_dir( $this->temp_data_dir );
+		$this->run_state = new \Newspack\ContentDiffMigrator\Logic\RunState( $this->temp_data_dir . '/run-state' );
+		$this->command->set_run_state( $this->run_state );
+
+		$this->run_search_command();
+		$this->run_migrate_command();
+
+		$reimported_post_id = $this->logic->get_current_post_id_by_old_id( 16001, $this->source_hostname );
+		$terms_after        = wp_get_post_terms( $reimported_post_id, 'category', [ 'fields' => 'names' ] );
+
+		$this->assertCount( 2, $terms_after, 'Post should have 2 terms after reimport.' );
+		$this->assertContains( 'Term Alpha', $terms_after, 'Term Alpha should remain.' );
+		$this->assertNotContains( 'Term Beta', $terms_after, 'Term Beta should be removed.' );
+		$this->assertContains( 'Term Gamma', $terms_after, 'Term Gamma should remain.' );
+	}
+
+	/**
+	 * Tests that when a post's author display_name changes on live, the local user is updated after reimport.
+	 *
+	 * @group posts-modified
+	 */
+	public function test_should_update_post_author_display_name_when_changed_on_live(): void {
+		global $wpdb;
+
+		// Create user on live.
+		$user = [
+			'ID'                  => 17001,
+			'user_login'          => 'testauthor17001',
+			'user_pass'           => 'hashed_pass',
+			'user_nicename'       => 'testauthor17001',
+			'user_email'          => 'testauthor17001@example.com',
+			'user_url'            => '',
+			'user_registered'     => '2024-01-01 10:00:00',
+			'user_activation_key' => '',
+			'user_status'         => 0,
+			'display_name'        => 'Original Display Name',
+		];
+		$wpdb->insert( $this->live_table_prefix . 'users', $user ); // phpcs:ignore
+
+		// Create post by this author.
+		$post = $this->create_post_fixture(
+			[
+				'ID'            => 17002,
+				'post_author'   => 17001,
+				'post_modified' => '2024-01-01 10:00:00',
+			]
+		);
+		$wpdb->insert( $this->live_table_prefix . 'posts', $post ); // phpcs:ignore
+
+		$this->run_search_command();
+		$this->run_migrate_command();
+
+		$new_post_id = $this->logic->get_current_post_id_by_old_id( 17002, $this->source_hostname );
+		$this->assertNotNull( $new_post_id, 'Post should be imported.' );
+
+		$local_user = get_user_by( 'login', 'testauthor17001' );
+		$this->assertNotFalse( $local_user, 'User should be imported.' );
+		$this->assertEquals( 'Original Display Name', $local_user->display_name );
+
+		// Update user display_name on live and modify post.
+		$wpdb->update( // phpcs:ignore
+			$this->live_table_prefix . 'users',
+			[ 'display_name' => 'Updated Display Name' ],
+			[ 'ID' => 17001 ]
+		);
+		$wpdb->update( // phpcs:ignore
+			$this->live_table_prefix . 'posts',
+			[
+				'post_modified'     => '2024-06-01 10:00:00',
+				'post_modified_gmt' => '2024-06-01 10:00:00',
+			],
+			[ 'ID' => 17002 ]
+		);
+
+		// Fresh run-state.
+		$this->cleanup_temp_dir( $this->temp_data_dir );
+		$this->run_state = new \Newspack\ContentDiffMigrator\Logic\RunState( $this->temp_data_dir . '/run-state' );
+		$this->command->set_run_state( $this->run_state );
+
+		$this->run_search_command();
+		$this->run_migrate_command();
+
+		// Refresh user object from DB.
+		$updated_user = get_user_by( 'login', 'testauthor17001' );
+		$this->assertEquals( 'Updated Display Name', $updated_user->display_name, 'User display_name should be updated after reimport.' );
 	}
 }

--- a/tests/Integration/CmdMigrateLiveContentRunStateTest.php
+++ b/tests/Integration/CmdMigrateLiveContentRunStateTest.php
@@ -535,12 +535,13 @@ class CmdMigrateLiveContentRunStateTest extends IntegrationTestCase {
 	// =========================================================================
 
 	/**
-	 * Tests that when wp_delete_post fails for a modified post, the post is:
+	 * Tests that when deletion of a modified post fails, the post is:
 	 * - Logged as error
 	 * - NOT saved to run-state as deleted
 	 * - Skipped during reimport (not duplicated)
 	 *
-	 * Uses the pre_delete_post filter to simulate deletion failure.
+	 * Simulates deletion failure by intercepting DELETE queries via the 'query' filter
+	 * and modifying them to exclude the target post ID.
 	 *
 	 * @group run-state
 	 * @group deletion-failure
@@ -587,20 +588,28 @@ class CmdMigrateLiveContentRunStateTest extends IntegrationTestCase {
 		$modified_ids = $this->run_state->get_modified_ids_map();
 		$this->assertArrayHasKey( 40001, $modified_ids, 'Post should be detected as modified.' );
 
-		// Add a filter to block deletion of this specific post.
-		$block_deletion_filter = function ( $delete, $post ) use ( $original_local_id ) {
-			if ( (int) $post->ID === (int) $original_local_id ) {
-				return false; // Block deletion - returning non-null short-circuits wp_delete_post.
+		// Block deletion by modifying DELETE queries to exclude the target post ID.
+		$block_deletion_filter = function ( $query ) use ( $original_local_id ) {
+			// Only intercept DELETE queries targeting the posts table with our post ID.
+			if (
+				preg_match( '/DELETE IGNORE FROM.*posts.*WHERE ID IN/i', $query )
+				&& strpos( $query, (string) $original_local_id ) !== false
+			) {
+				// Remove target ID from the IN clause to simulate failed deletion.
+				$query = preg_replace( '/\b' . $original_local_id . '\b,?\s*/', '', $query );
+				// Clean up trailing comma if the ID was last in the list.
+				$query = preg_replace( '/,\s*\)/', ')', $query );
+				// If IN clause is now empty, replace with a no-op condition.
+				$query = preg_replace( '/WHERE ID IN\s*\(\s*\)/i', 'WHERE 1=0', $query );
 			}
-			return $delete;
+			return $query;
 		};
-		add_filter( 'pre_delete_post', $block_deletion_filter, 10, 3 );
+		add_filter( 'query', $block_deletion_filter );
 
-		// Run migrate - deletion should fail.
+		// Run migrate - deletion should fail for our target post.
 		$this->run_migrate_command();
 
-		// Remove the filter.
-		remove_filter( 'pre_delete_post', $block_deletion_filter, 10 );
+		remove_filter( 'query', $block_deletion_filter );
 
 		// Verify post still exists (deletion failed).
 		$post_after_migrate = get_post( $original_local_id );
@@ -616,6 +625,9 @@ class CmdMigrateLiveContentRunStateTest extends IntegrationTestCase {
 
 	/**
 	 * Tests that on resume after deletion failure, the system retries deletion.
+	 *
+	 * Simulates deletion failure by intercepting DELETE queries via the 'query' filter
+	 * and modifying them to exclude the target post ID on the first attempt.
 	 *
 	 * @group run-state
 	 * @group deletion-failure
@@ -658,21 +670,31 @@ class CmdMigrateLiveContentRunStateTest extends IntegrationTestCase {
 
 		$this->run_search_command();
 
-		// First migrate attempt - block deletion.
-		$deletion_attempt_count = 0;
-		$block_first_deletion   = function ( $delete, $post ) use ( $original_local_id, &$deletion_attempt_count ) {
-			if ( (int) $post->ID === (int) $original_local_id ) {
-				$deletion_attempt_count++;
-				if ( 1 === $deletion_attempt_count ) {
-					return false; // Block first attempt - returning non-null short-circuits wp_delete_post.
-				}
+		// First migrate attempt - block deletion by modifying DELETE queries to exclude the target post ID.
+		$migrate_attempt_count = 0;
+		$block_deletion_filter = function ( $query ) use ( $original_local_id, &$migrate_attempt_count ) {
+			// Only intercept DELETE queries targeting the posts table with our post ID.
+			if (
+				0 === $migrate_attempt_count
+				&& preg_match( '/DELETE IGNORE FROM.*posts.*WHERE ID IN/i', $query )
+				&& strpos( $query, (string) $original_local_id ) !== false
+			) {
+				// Remove target ID from the IN clause to simulate failed deletion.
+				$query = preg_replace( '/\b' . $original_local_id . '\b,?\s*/', '', $query );
+				// Clean up trailing comma if the ID was last in the list.
+				$query = preg_replace( '/,\s*\)/', ')', $query );
+				// If IN clause is now empty, replace with a no-op condition.
+				$query = preg_replace( '/WHERE ID IN\s*\(\s*\)/i', 'WHERE 1=0', $query );
 			}
-			return $delete;
+			return $query;
 		};
-		add_filter( 'pre_delete_post', $block_first_deletion, 10, 3 );
+		add_filter( 'query', $block_deletion_filter );
 
-		// First migrate - deletion fails.
+		// First migrate - deletion fails for our target post.
 		$this->run_migrate_command();
+		$migrate_attempt_count++;
+
+		remove_filter( 'query', $block_deletion_filter );
 
 		// Verify post still exists.
 		$post_after_first = get_post( $original_local_id );
@@ -680,8 +702,6 @@ class CmdMigrateLiveContentRunStateTest extends IntegrationTestCase {
 
 		// Second migrate (resume) - deletion should succeed now.
 		$this->run_migrate_command();
-
-		remove_filter( 'pre_delete_post', $block_first_deletion, 10 );
 
 		// After second attempt, the post should be deleted and reimported.
 		$deleted_map = $this->run_state->get_deleted_modified_ids_map();

--- a/tests/unit/Logic/ContentDiffLogicTest.php
+++ b/tests/unit/Logic/ContentDiffLogicTest.php
@@ -1347,6 +1347,107 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that orphaned term relationships on live are skipped.
+	 * Scenario: Live has term_taxonomy row but no corresponding term row.
+	 * This orphaned data should not cause false positive modified detection.
+	 */
+	public function test_filter_modified_live_ids_should_skip_orphaned_term_relationships(): void {
+		global $wpdb;
+
+		// Create a local post with a category term.
+		$local_post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$local_cat     = wp_insert_term( 'Real Category', 'category' );
+		$local_cat_id  = $local_cat['term_id'];
+		wp_set_object_terms( $local_post_id, [ $local_cat_id ], 'category' );
+
+		// Simulate "live" post with same category PLUS an orphaned term relationship.
+		$live_post_id       = 9040;
+		$live_cat_id        = 9540;
+		$orphan_term_id     = 9999;
+		$orphan_term_tax_id = 9998;
+		$live_prefix        = 'cdiff_';
+
+		// Create live tables.
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}posts" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}posts LIKE {$wpdb->posts}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}postmeta" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}postmeta LIKE {$wpdb->postmeta}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}terms" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}terms LIKE {$wpdb->terms}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_taxonomy" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}term_taxonomy LIKE {$wpdb->term_taxonomy}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_relationships" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}term_relationships LIKE {$wpdb->term_relationships}" ); // phpcs:ignore
+
+		// Insert live post.
+		$wpdb->insert( // phpcs:ignore
+			$live_prefix . 'posts',
+			[
+				'ID'            => $live_post_id,
+				'post_status'   => 'publish',
+				'post_type'     => 'post',
+				'post_author'   => 1,
+				'post_modified' => '2025-01-01 12:00:00',
+				'post_title'    => 'Live Post Orphan Term',
+				'post_name'     => 'live-post-orphan-term',
+				'post_date'     => '2025-01-01 12:00:00',
+			]
+		);
+
+		// Insert live category (valid - has both term and term_taxonomy rows).
+		$wpdb->insert( $live_prefix . 'terms', [ 'term_id' => $live_cat_id, 'name' => 'Real Category', 'slug' => 'real-category' ] ); // phpcs:ignore
+		$wpdb->insert( $live_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => $live_cat_id, 'term_id' => $live_cat_id, 'taxonomy' => 'category', 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $live_prefix . 'term_relationships', [ 'object_id' => $live_post_id, 'term_taxonomy_id' => $live_cat_id ] ); // phpcs:ignore
+
+		// Insert ORPHANED term relationship: term_taxonomy exists but term row does NOT.
+		$wpdb->insert( $live_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => $orphan_term_tax_id, 'term_id' => $orphan_term_id, 'taxonomy' => 'category', 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $live_prefix . 'term_relationships', [ 'object_id' => $live_post_id, 'term_taxonomy_id' => $orphan_term_tax_id ] ); // phpcs:ignore
+		// NOTE: No insert into cdiff_terms for $orphan_term_id - this is the orphan!
+
+		$live_posts  = [
+			[
+				'ID'            => (string) $live_post_id,
+				'post_modified' => '2025-01-01 12:00:00',
+				'post_status'   => 'publish',
+				'post_author'   => '1',
+				'comment_count' => '0',
+			],
+		];
+		$local_posts = [
+			[
+				'ID'            => (string) $local_post_id,
+				'post_modified' => '2025-01-01 12:00:00',
+				'post_status'   => 'publish',
+				'post_author'   => '1',
+				'comment_count' => '0',
+			],
+		];
+
+		$old_id_map      = [ $live_post_id => $local_post_id ];
+		$term_old_id_map = [ $live_cat_id => $local_cat_id ];
+
+		$result = $this->logic->filter_modified_live_ids(
+			$live_posts,
+			$local_posts,
+			$old_id_map,
+			$live_prefix,
+			[],
+			[],
+			$term_old_id_map,
+			[ 'category' ]
+		);
+
+		// Clean up.
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}posts" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}postmeta" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}terms" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_taxonomy" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_relationships" ); // phpcs:ignore
+
+		$this->assertCount( 0, $result, 'Post should NOT be flagged as modified due to orphaned term relationship on live.' );
+	}
+
+	/**
 	 * =========================================================================
 	 * match_local_to_live_posts Tests
 	 * =========================================================================

--- a/tests/unit/Logic/ContentDiffLogicTest.php
+++ b/tests/unit/Logic/ContentDiffLogicTest.php
@@ -615,7 +615,7 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 		// old_id mapping: live_id 1 => local_id 10.
 		$old_id_map = [ 1 => 10 ];
 
-		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map );
+		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map, '', [], [], [], [] );
 
 		$this->assertCount( 1, $result );
 		$this->assertSame( 1, $result[0]['live_id'] );
@@ -642,7 +642,7 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 		// Live ID 1 is NOT in mapping - it's a new post, not modified.
 		$old_id_map = [];
 
-		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map );
+		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map, '', [], [], [], [] );
 
 		$this->assertEmpty( $result );
 	}
@@ -666,13 +666,13 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 		];
 		$old_id_map  = [ 1 => 10 ];
 
-		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map );
+		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map, '', [], [], [], [] );
 
 		$this->assertEmpty( $result );
 	}
 
 	public function test_filter_modified_live_ids_should_handle_empty_arrays(): void {
-		$this->assertEmpty( $this->logic->filter_modified_live_ids( [], [], [] ) );
+		$this->assertEmpty( $this->logic->filter_modified_live_ids( [], [], [], '', [], [], [], [] ) );
 		$this->assertEmpty(
 			$this->logic->filter_modified_live_ids(
 				[],
@@ -684,8 +684,13 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 						'post_author'   => 1,
 					],
 				],
+				[],
+				'',
+				[],
+				[],
+				[],
 				[]
-			) 
+			)
 		);
 	}
 
@@ -708,7 +713,7 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 		];
 		$old_id_map  = [ 1 => 10 ];
 
-		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map );
+		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map, '', [], [], [], [] );
 
 		$this->assertCount( 1, $result );
 		$this->assertSame( 10, $result[0]['local_id'] );
@@ -735,7 +740,7 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 		];
 		$old_id_map  = [ 1 => 10 ];
 
-		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map );
+		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map, '', [], [], [], [] );
 
 		$this->assertCount( 1, $result );
 		$this->assertSame( 1, $result[0]['live_id'] );
@@ -768,7 +773,7 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 		$old_id_map      = [ 1 => 10 ];
 		$user_old_id_map = [ 50 => 5 ]; // Local user 5 maps to live user 50, but live post has author 99.
 
-		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map, '', $user_old_id_map );
+		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map, '', $user_old_id_map, [], [], [] );
 
 		$this->assertCount( 1, $result );
 		$this->assertArrayHasKey( 'changes', $result[0] );
@@ -800,7 +805,7 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 		$old_id_map      = [ 1 => 10 ];
 		$user_old_id_map = [ 100 => 20 ]; // Different user mapping, local user 5 not in map.
 
-		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map, '', $user_old_id_map );
+		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map, '', $user_old_id_map, [], [], [] );
 
 		$this->assertCount( 0, $result, 'Should not detect modification when local author has no mapping.' );
 	}
@@ -826,7 +831,7 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 		];
 		$old_id_map  = [ 1 => 10 ];
 
-		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map );
+		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map, '', [], [], [], [] );
 
 		$this->assertCount( 1, $result );
 		$this->assertArrayHasKey( 'changes', $result[0] );
@@ -923,7 +928,8 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 			$live_prefix,
 			[], // user_old_id_map
 			[], // attachment_old_id_map
-			$term_old_id_map
+			$term_old_id_map,
+			[ 'category' ]
 		);
 
 		// Clean up live tables.
@@ -1028,7 +1034,8 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 			$live_prefix,
 			[], // user_old_id_map
 			[], // attachment_old_id_map
-			$term_old_id_map
+			$term_old_id_map,
+			[ 'category' ]
 		);
 
 		// Clean up.
@@ -2815,7 +2822,7 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 
 		$old_id_map = [ 100 => 1 ];
 
-		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map );
+		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map, '', [], [], [], [] );
 
 		$this->assertCount( 1, $result );
 		$this->assertEquals( 100, $result[0]['live_id'] );
@@ -2845,7 +2852,7 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 
 		$old_id_map = [ 100 => 1 ];
 
-		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map );
+		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map, '', [], [], [], [] );
 
 		$this->assertCount( 1, $result );
 	}
@@ -2880,7 +2887,7 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 		// Only 100 is mapped, 101 is not imported yet.
 		$old_id_map = [ 100 => 1 ];
 
-		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map );
+		$result = $this->logic->filter_modified_live_ids( $live_posts, $local_posts, $old_id_map, '', [], [], [], [] );
 
 		$this->assertCount( 1, $result );
 		$this->assertEquals( 100, $result[0]['live_id'] );

--- a/tests/unit/Logic/ContentDiffLogicTest.php
+++ b/tests/unit/Logic/ContentDiffLogicTest.php
@@ -3320,6 +3320,107 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests ID match takes priority over slug match when duplicate slugs exist.
+	 * Scenario: Live has duplicate slugs — ID=100 and ID=200 both have slug "same-slug".
+	 * Local has ID=100. Should match to live 100 (by ID), not live 200.
+	 */
+	public function test_match_local_to_live_terms_should_prefer_id_match_over_slug_match(): void {
+		$local_terms = [
+			[
+				'term_id'  => 100,
+				'slug'     => 'same-slug',
+				'name'     => 'Same Name',
+				'taxonomy' => 'author',
+			],
+		];
+
+		$live_terms = [
+			[
+				'term_id'  => 100,
+				'slug'     => 'same-slug',
+				'name'     => 'Same Name',
+				'taxonomy' => 'author',
+			],
+			[
+				'term_id'  => 200,
+				'slug'     => 'same-slug',
+				'name'     => 'Same Name',
+				'taxonomy' => 'author',
+			],
+		];
+
+		$result = $this->logic->match_local_to_live_terms( $local_terms, $live_terms );
+
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 100, $result[0]['local_id'] );
+		$this->assertEquals( 100, $result[0]['live_id'] );
+	}
+
+	/**
+	 * Tests slug fallback when local ID doesn't exist on live but slug matches.
+	 * Scenario: Local ID=300, live has duplicate slugs ID=100 and ID=200.
+	 * No ID match, so falls back to first slug match.
+	 */
+	public function test_match_local_to_live_terms_should_fallback_to_slug_when_no_id_match(): void {
+		$local_terms = [
+			[
+				'term_id'  => 300,
+				'slug'     => 'same-slug',
+				'name'     => 'Same Name',
+				'taxonomy' => 'author',
+			],
+		];
+
+		$live_terms = [
+			[
+				'term_id'  => 100,
+				'slug'     => 'same-slug',
+				'name'     => 'Same Name',
+				'taxonomy' => 'author',
+			],
+			[
+				'term_id'  => 200,
+				'slug'     => 'same-slug',
+				'name'     => 'Same Name',
+				'taxonomy' => 'author',
+			],
+		];
+
+		$result = $this->logic->match_local_to_live_terms( $local_terms, $live_terms );
+
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 300, $result[0]['local_id'] );
+		$this->assertEquals( 100, $result[0]['live_id'] );
+	}
+
+	/**
+	 * Tests no match when neither ID nor slug matches.
+	 */
+	public function test_match_local_to_live_terms_should_return_empty_when_no_match(): void {
+		$local_terms = [
+			[
+				'term_id'  => 999,
+				'slug'     => 'unique-slug',
+				'name'     => 'Unique',
+				'taxonomy' => 'category',
+			],
+		];
+
+		$live_terms = [
+			[
+				'term_id'  => 100,
+				'slug'     => 'other-slug',
+				'name'     => 'Other',
+				'taxonomy' => 'category',
+			],
+		];
+
+		$result = $this->logic->match_local_to_live_terms( $local_terms, $live_terms );
+
+		$this->assertEmpty( $result );
+	}
+
+	/**
 	 * =========================================================================
 	 * update_modified_users Tests
 	 * =========================================================================

--- a/tests/unit/Logic/ContentDiffLogicTest.php
+++ b/tests/unit/Logic/ContentDiffLogicTest.php
@@ -1044,6 +1044,302 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that terms in taxonomies NOT in the $taxonomies parameter are skipped.
+	 * This prevents false positives for non-attributed taxonomies like ef_editorial_meta.
+	 */
+	public function test_filter_modified_live_ids_should_not_flag_modified_when_term_in_non_specified_taxonomy(): void {
+		global $wpdb;
+
+		// Register a custom taxonomy not in DEFAULT_TAXONOMIES.
+		register_taxonomy( 'ef_editorial_meta', 'post' );
+
+		// Create a local post with a term in ef_editorial_meta.
+		$local_post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$local_term    = wp_insert_term( 'In Progress', 'ef_editorial_meta' );
+		$local_term_id = $local_term['term_id'];
+		wp_set_object_terms( $local_post_id, [ $local_term_id ], 'ef_editorial_meta' );
+
+		// Simulate "live" post with a DIFFERENT ef_editorial_meta term.
+		$live_post_id = 9010;
+		$live_term_id = 9510; // Different term, no mapping exists.
+		$live_prefix  = 'cdiff_';
+
+		// Create live tables.
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}posts" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}posts LIKE {$wpdb->posts}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}postmeta" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}postmeta LIKE {$wpdb->postmeta}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}terms" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}terms LIKE {$wpdb->terms}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_taxonomy" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}term_taxonomy LIKE {$wpdb->term_taxonomy}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_relationships" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}term_relationships LIKE {$wpdb->term_relationships}" ); // phpcs:ignore
+
+		// Insert live post.
+		$wpdb->insert( // phpcs:ignore
+			$live_prefix . 'posts',
+			[
+				'ID'            => $live_post_id,
+				'post_status'   => 'publish',
+				'post_type'     => 'post',
+				'post_author'   => 1,
+				'post_modified' => '2025-01-01 12:00:00',
+				'post_title'    => 'Live Post',
+				'post_name'     => 'live-post-ef',
+				'post_date'     => '2025-01-01 12:00:00',
+			]
+		);
+
+		// Insert live term in ef_editorial_meta (not in $taxonomies param).
+		$wpdb->insert( $live_prefix . 'terms', [ 'term_id' => $live_term_id, 'name' => 'Draft', 'slug' => 'draft' ] ); // phpcs:ignore
+		$wpdb->insert( $live_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => $live_term_id, 'term_id' => $live_term_id, 'taxonomy' => 'ef_editorial_meta', 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $live_prefix . 'term_relationships', [ 'object_id' => $live_post_id, 'term_taxonomy_id' => $live_term_id ] ); // phpcs:ignore
+
+		$live_posts  = [
+			[
+				'ID'            => (string) $live_post_id,
+				'post_modified' => '2025-01-01 12:00:00',
+				'post_status'   => 'publish',
+				'post_author'   => '1',
+				'comment_count' => '0',
+			],
+		];
+		$local_posts = [
+			[
+				'ID'            => (string) $local_post_id,
+				'post_modified' => '2025-01-01 12:00:00',
+				'post_status'   => 'publish',
+				'post_author'   => '1',
+				'comment_count' => '0',
+			],
+		];
+
+		$old_id_map      = [ $live_post_id => $local_post_id ];
+		$term_old_id_map = []; // No term mapping (simulates non-attributed taxonomy).
+
+		// Pass $taxonomies = ['category'] - ef_editorial_meta should be skipped.
+		$result = $this->logic->filter_modified_live_ids(
+			$live_posts,
+			$local_posts,
+			$old_id_map,
+			$live_prefix,
+			[], // user_old_id_map
+			[], // attachment_old_id_map
+			$term_old_id_map,
+			[ 'category' ] // Only compare 'category', skip ef_editorial_meta.
+		);
+
+		// Clean up.
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}posts" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}postmeta" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}terms" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_taxonomy" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_relationships" ); // phpcs:ignore
+
+		$this->assertCount( 0, $result, 'Post should NOT be flagged as modified when term is in non-specified taxonomy.' );
+	}
+
+	/**
+	 * Tests backward compatibility when $taxonomies param is empty.
+	 * When empty, taxonomy comparison should be skipped entirely.
+	 */
+	public function test_filter_modified_live_ids_should_skip_taxonomy_comparison_when_taxonomies_param_empty(): void {
+		global $wpdb;
+
+		// Create a local post with a category term.
+		$local_post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$local_term    = wp_insert_term( 'Test Category Empty', 'category' );
+		$local_term_id = $local_term['term_id'];
+		wp_set_object_terms( $local_post_id, [ $local_term_id ], 'category' );
+
+		// Simulate "live" post with a DIFFERENT category term (would normally trigger modified).
+		$live_post_id = 9020;
+		$live_term_id = 9520;
+		$live_prefix  = 'cdiff_';
+
+		// Create live tables.
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}posts" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}posts LIKE {$wpdb->posts}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}postmeta" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}postmeta LIKE {$wpdb->postmeta}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}terms" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}terms LIKE {$wpdb->terms}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_taxonomy" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}term_taxonomy LIKE {$wpdb->term_taxonomy}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_relationships" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}term_relationships LIKE {$wpdb->term_relationships}" ); // phpcs:ignore
+
+		// Insert live post.
+		$wpdb->insert( // phpcs:ignore
+			$live_prefix . 'posts',
+			[
+				'ID'            => $live_post_id,
+				'post_status'   => 'publish',
+				'post_type'     => 'post',
+				'post_author'   => 1,
+				'post_modified' => '2025-01-01 12:00:00',
+				'post_title'    => 'Live Post Empty Tax',
+				'post_name'     => 'live-post-empty-tax',
+				'post_date'     => '2025-01-01 12:00:00',
+			]
+		);
+
+		// Insert live term.
+		$wpdb->insert( $live_prefix . 'terms', [ 'term_id' => $live_term_id, 'name' => 'Different Cat', 'slug' => 'different-cat' ] ); // phpcs:ignore
+		$wpdb->insert( $live_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => $live_term_id, 'term_id' => $live_term_id, 'taxonomy' => 'category', 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $live_prefix . 'term_relationships', [ 'object_id' => $live_post_id, 'term_taxonomy_id' => $live_term_id ] ); // phpcs:ignore
+
+		$live_posts  = [
+			[
+				'ID'            => (string) $live_post_id,
+				'post_modified' => '2025-01-01 12:00:00',
+				'post_status'   => 'publish',
+				'post_author'   => '1',
+				'comment_count' => '0',
+			],
+		];
+		$local_posts = [
+			[
+				'ID'            => (string) $local_post_id,
+				'post_modified' => '2025-01-01 12:00:00',
+				'post_status'   => 'publish',
+				'post_author'   => '1',
+				'comment_count' => '0',
+			],
+		];
+
+		$old_id_map      = [ $live_post_id => $local_post_id ];
+		$term_old_id_map = [ $live_term_id => $local_term_id ];
+
+		// Pass $taxonomies = [] - taxonomy comparison should be skipped.
+		$result = $this->logic->filter_modified_live_ids(
+			$live_posts,
+			$local_posts,
+			$old_id_map,
+			$live_prefix,
+			[], // user_old_id_map
+			[], // attachment_old_id_map
+			$term_old_id_map,
+			[] // Empty taxonomies = skip comparison.
+		);
+
+		// Clean up.
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}posts" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}postmeta" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}terms" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_taxonomy" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_relationships" ); // phpcs:ignore
+
+		$this->assertCount( 0, $result, 'Post should NOT be flagged as modified when $taxonomies param is empty (skip comparison).' );
+	}
+
+	/**
+	 * Tests that only terms in specified taxonomies are compared.
+	 * Post has terms in both 'category' and 'post_tag', but only 'category' is in $taxonomies.
+	 * Differences in 'post_tag' should be ignored.
+	 */
+	public function test_filter_modified_live_ids_should_only_compare_terms_in_specified_taxonomies(): void {
+		global $wpdb;
+
+		// Create a local post with category and post_tag terms.
+		$local_post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$local_cat     = wp_insert_term( 'Same Category', 'category' );
+		$local_cat_id  = $local_cat['term_id'];
+		$local_tag     = wp_insert_term( 'Local Tag', 'post_tag' );
+		$local_tag_id  = $local_tag['term_id'];
+		wp_set_object_terms( $local_post_id, [ $local_cat_id ], 'category' );
+		wp_set_object_terms( $local_post_id, [ $local_tag_id ], 'post_tag' );
+
+		// Simulate "live" post with same category but DIFFERENT post_tag.
+		$live_post_id = 9030;
+		$live_cat_id  = 9530; // Maps to local_cat_id.
+		$live_tag_id  = 9531; // Different tag, no mapping.
+		$live_prefix  = 'cdiff_';
+
+		// Create live tables.
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}posts" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}posts LIKE {$wpdb->posts}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}postmeta" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}postmeta LIKE {$wpdb->postmeta}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}terms" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}terms LIKE {$wpdb->terms}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_taxonomy" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}term_taxonomy LIKE {$wpdb->term_taxonomy}" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_relationships" ); // phpcs:ignore
+		$wpdb->query( "CREATE TABLE {$live_prefix}term_relationships LIKE {$wpdb->term_relationships}" ); // phpcs:ignore
+
+		// Insert live post.
+		$wpdb->insert( // phpcs:ignore
+			$live_prefix . 'posts',
+			[
+				'ID'            => $live_post_id,
+				'post_status'   => 'publish',
+				'post_type'     => 'post',
+				'post_author'   => 1,
+				'post_modified' => '2025-01-01 12:00:00',
+				'post_title'    => 'Live Post Selective Tax',
+				'post_name'     => 'live-post-selective-tax',
+				'post_date'     => '2025-01-01 12:00:00',
+			]
+		);
+
+		// Insert live category (same as local).
+		$wpdb->insert( $live_prefix . 'terms', [ 'term_id' => $live_cat_id, 'name' => 'Same Category', 'slug' => 'same-category' ] ); // phpcs:ignore
+		$wpdb->insert( $live_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => $live_cat_id, 'term_id' => $live_cat_id, 'taxonomy' => 'category', 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $live_prefix . 'term_relationships', [ 'object_id' => $live_post_id, 'term_taxonomy_id' => $live_cat_id ] ); // phpcs:ignore
+
+		// Insert live tag (different from local).
+		$wpdb->insert( $live_prefix . 'terms', [ 'term_id' => $live_tag_id, 'name' => 'Live Tag', 'slug' => 'live-tag' ] ); // phpcs:ignore
+		$wpdb->insert( $live_prefix . 'term_taxonomy', [ 'term_taxonomy_id' => $live_tag_id, 'term_id' => $live_tag_id, 'taxonomy' => 'post_tag', 'count' => 1 ] ); // phpcs:ignore
+		$wpdb->insert( $live_prefix . 'term_relationships', [ 'object_id' => $live_post_id, 'term_taxonomy_id' => $live_tag_id ] ); // phpcs:ignore
+
+		$live_posts  = [
+			[
+				'ID'            => (string) $live_post_id,
+				'post_modified' => '2025-01-01 12:00:00',
+				'post_status'   => 'publish',
+				'post_author'   => '1',
+				'comment_count' => '0',
+			],
+		];
+		$local_posts = [
+			[
+				'ID'            => (string) $local_post_id,
+				'post_modified' => '2025-01-01 12:00:00',
+				'post_status'   => 'publish',
+				'post_author'   => '1',
+				'comment_count' => '0',
+			],
+		];
+
+		$old_id_map = [ $live_post_id => $local_post_id ];
+		// Only category is mapped, post_tag is not (simulating selective attribution).
+		$term_old_id_map = [ $live_cat_id => $local_cat_id ];
+
+		// Pass $taxonomies = ['category'] - post_tag differences should be ignored.
+		$result = $this->logic->filter_modified_live_ids(
+			$live_posts,
+			$local_posts,
+			$old_id_map,
+			$live_prefix,
+			[], // user_old_id_map
+			[], // attachment_old_id_map
+			$term_old_id_map,
+			[ 'category' ] // Only compare 'category'.
+		);
+
+		// Clean up.
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}posts" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}postmeta" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}terms" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_taxonomy" ); // phpcs:ignore
+		$wpdb->query( "DROP TABLE IF EXISTS {$live_prefix}term_relationships" ); // phpcs:ignore
+
+		$this->assertCount( 0, $result, 'Post should NOT be flagged as modified when only non-specified taxonomy (post_tag) differs.' );
+	}
+
+	/**
 	 * =========================================================================
 	 * match_local_to_live_posts Tests
 	 * =========================================================================


### PR DESCRIPTION
# TL;DR, multiple improvements

Improvements `1.`, `2.` and `3.` all came from the issues noted with Chicago (Publisher) -- there were multiple root causes in this database for the false positive "modified" behavior.

1. **🔴 Fix** -- <ins>False positive "modified" posts</ins> - when checking "modified" terms, terms with taxonomies which are not migrated were also being checked
2. **🟡 Hardening** -- <ins>DB terms with duplicate slugs</ins> -- WP allows dupe slugs for terms with different taxonomies, but not for same taxonomies. In Chicago DB, there are multiple author terms with same slugs -- now CDiff is handling this invalid data correctly with a special check for terms, at no performance impact
3. **🟡 Hardening** -- <ins>Orphaned terms in DB</ins> -- "orphaned terms" are term_relationships with term_ids which do not exist in terms table -- now handing this invalid data correctly, with an O(1) lookup of orphaned terms
4. **🟢  Improvement** -- <ins>Full MDCS test coverage</ins> -- motivated by the false positive "modified" issue, analyzed existing test coverage against the full Migration Data Consistency Standard, identified and added 7 additional tests to get full coverage
5. **🟢 Improvement** -- <ins>Faster posts deletion</ins> -- replaced slow wp_post_delete() with batched direct queries
6. **🟢 Improvement** -- <ins>Cleaned up some CLI messages</ins> -- removed some confusing and unnecessary messaging, made output lighter and simpler

Noting that a release was already created from this PR for wide range testing on real life databases https://github.com/Automattic/newspack-content-diff-migrator/releases/tag/2.1.1.

---

# Individual changes

## 1. Fix for false positive modified

Issue -- **false positives "modified" posts get reimported unnecessarily**:
- example, multiple posts were marked as "modified" though they should not be:
```
{"live_id":15,"local_id":15,"changes":{"taxonomies":{"live_terms_not_found_on_local":[{"live_term_id":20,"name":"First Draft Date","taxonomy":"ef_editorial_meta"},{"live_term_id":21,"name":"Assignment","taxonomy":"ef_editorial_meta"}]}}}
```

Root cause:
- only the terms from selected taxonomies get migrated, and get the metas (either if provided `--custom-taxonomies-csv` or `DEFAULT_TAXONOMIES = ['category', 'post_tag', 'author', 'brand']`)
- additional custom taxonomies (example taxonomy here is `ef_editorial_meta`) which are not in this list, those terms never get migration metas
- taxonomy comparison in `filter_modified_live_ids() >> // Check 6: taxonomies changed (compare term sets)` compared all the live taxonomies for live post, including these custom ones which were not migrated, but since these custom terms have no attribution metas, it said "not found on local" for those terms

Fix:
- `filter_modified_live_ids() >> Check 6` to filter/compare live posts' terms only by those taxonomies which are being migrated

Implementation:
- added tests which were missing to cover this the Newspack Migration Data Consistency Standard more fully
  - unit `ContentDiffLogicTest.php`:
    - `test_filter_modified_live_ids_should_not_flag_modified_when_term_in_non_specified_taxonomy`
    - `test_filter_modified_live_ids_should_skip_taxonomy_comparison_when_taxonomies_param_empty`
    - `test_filter_modified_live_ids_should_only_compare_terms_in_specified_taxonomies`
  - integration `CmdMigrateLiveContentMigrationDataConsistencyStandardTest.php`:
    - `test_should_not_detect_modified_when_taxonomy_not_in_attribution_list`
    - `test_should_detect_modified_only_for_taxonomies_in_custom_taxonomies_csv`

---

## 2. Duplicate term slugs on live sites

This update handles duplicate term slugs on live correctly. WordPress allows same term slugs for terms with different taxonomies, but does not allow them for terms in the same taxonomy. However in real life, we're seeing live databases with such corrupt data (from legacy imports, direct DB inserts, or pre-WP 4.1 behavior).

Before this improvement, `match_local_to_live_terms()` produced **non-deterministic results** when duplicates existed — it used a lookup keyed by `slug|taxonomy` where the last term processed overwrote earlier ones. This caused incorrect attribution (e.g., local term 10050 attributed to live term 170220 instead of 10050), which then triggered false positive "modified" detection during subsequent migrations.

**Example from one publisher (CR.com) -- masked actual name/slug for privacy reasons:**
- Live has term ID=10050, slug="jeff-k****-lowe******", taxonomy="author"
- Live has term ID=170220, slug="jeff-k****-lowe******", taxonomy="author" (duplicate)
- Local has term ID=10050 (cloned from live)
- Before: local 10050 → live 170220 (wrong, depends on iteration order)
- After: local 10050 → live 10050 (correct, ID match takes priority)

**Fix:** Priority-based matching in `match_local_to_live_terms()`:
1. **Priority 1:** Direct term_id match — if local term ID exists on live, use it (expected on cloned sites)
2. **Priority 2:** Slug+taxonomy fallback — for non-cloned sites or when IDs differ

---

## 3. Orphaned term relationships on live sites

Live sites can have orphaned term data where `term_taxonomy` rows exist but the corresponding `terms` row does not. This corrupt data caused false positive "modified" detection because Check #6 (taxonomy comparison) added the orphaned term_id to the live terms list, but it could never be found on local.

**Example from CR.com:**
- `cdiff_term_taxonomy` has: term_taxonomy_id=11090, term_id=103, taxonomy=post_tag
- `cdiff_terms` has NO row for term_id=103
- Before: Post flagged as "modified" due to ghost term 103
- After: Orphaned term skipped, post not falsely flagged

**Fix:** Added validation in `filter_modified_live_ids()` Check #6 to verify the term exists via `select_term_row()` before including it in the comparison.

---

## 4. Full MDCS test coverage

Newspack MDCS test coverage review (Migration Data Consistency Standard). Motivated by the previous bug, I've reviewed the entire MDCS standard's test coverage, and found 7 more tests to add.

#### **POSTS/CPTs \- 6 Modification Checks**

| Status | Check | Field | Existing Test |
| ----- | ----- | ----- | ----- |
| ✅ | 1 | `post_modified` | `test_should_filter_modified_posts_when_post_modified_date_changed` |
| ✅ | 2 | `post_status` | `test_should_filter_modified_posts_when_post_status_changed` |
| ❌ GAP | 3 | `comment_count` | **NONE** |
| ✅ | 4 | `post_author` | `test_should_filter_modified_posts_when_post_author_changed` |
| ✅ | 5 | `_thumbnail_id` | `test_should_filter_modified_posts_when_thumbnail_id_changed` |
| ✅ | 5b | `_thumbnail_id` (added later) | `test_should_filter_modified_posts_when_thumbnail_id_did_not_exist_initially_and_was_later_added_on_live` |
| ✅ | 6 | Taxonomies (added) | `test_should_filter_modified_posts_when_taxonomies_changed` |
| ✅ | 6b | Taxonomies (removed) | `test_should_filter_modified_posts_when_term_removed_on_live` |
| ❌ GAP | 6c | Taxonomies (non-attributed) | **NONE** (the bug we found) |
| ❌ GAP | 6d | Locally added terms skip | **NONE** |

#### **POSTS \- Identifier Fields (should NOT trigger reimport)**

| Status | Field | Existing Test |
| ----- | ----- | ----- |
| ✅ | Title | `test_should_not_update_post_title_when_changed_on_live` |
| ✅ | Slug | `test_should_not_update_post_slug_when_changed_on_live` |
| ✅ | Date published | `test_should_not_update_post_date_published_when_changed_on_live` |

#### **POSTS \- NOT Detected (negative tests)**

| Status | Field | Existing Test |
| ----- | ----- | ----- |
| ❌ GAP | Postmeta-only changes | **NONE** |
| ❌ GAP | Comment-only changes | **NONE** |

#### **POSTS \- Reimport Behavior**

| Status | Behavior | Existing Test |
| ----- | ----- | ----- |
| ✅ | Updates content | `test_reimport_should_update_post_content` |
| ✅ | Updates postmeta | `test_reimport_should_include_updated_post_meta` |
| ✅ | Preserves old\_id meta | `test_reimport_should_preserve_old_id_meta` |
| ✅ | Updates featured image | `test_reimport_should_update_featured_image_id` |
| ✅ | Removes deleted comments | `test_should_remove_comment_when_reimporting_modified_post_with_comment_deleted_on_live` |
| ✅ | Removes deleted postmeta | `test_should_remove_postmeta_when_reimporting_modified_post_with_meta_deleted_on_live` |
| ✅ | Updates parent | `test_reimport_post_with_parent_should_update_parent_correctly` |
| ✅ | Preserves local ID | `test_reimport_should_preserve_local_post_id` (PostsModifiedTest) |
| ❌ GAP | Updates block IDs | **NONE** (in MDCS test file) |

#### **PAGES**

| Status | Behavior | Existing Test |
| ----- | ----- | ----- |
| ✅ | Not detected as modified | `test_should_not_detect_pages_as_modified_per_standard` |
| ✅ | Pages excluded, posts detected | `test_should_detect_modified_posts_but_not_pages_in_same_run` |
| ✅ | New pages NOT imported on consecutive runs | `test_should_not_import_new_pages_on_consecutive_runs` |

#### **CPTs**

| Status | Behavior | Existing Test |
| ----- | ----- | ----- |
| ✅ | Detected like posts | `test_should_detect_custom_cpt_as_modified_when_post_modified_changes` |

#### **ATTACHMENTS**

| Status | Field | Existing Test |
| ----- | ----- | ----- |
| ✅ | Caption | `test_should_update_attachment_caption_when_changed_on_live` |
| ✅ | Description | `test_should_update_attachment_description_when_changed_on_live` |
| ✅ | Alt text | `test_should_update_attachment_alt_text_when_changed_on_live` |
| ✅ | Credit | `test_should_update_attachment_media_credit_when_changed_on_live` |
| ✅ | Credit URL | `test_should_update_attachment_credit_url_when_changed_on_live` |
| ❌ GAP | NOT checked like posts | **NONE** |

#### **USERS**

| Status | Field | Existing Test |
| ----- | ----- | ----- |
| ✅ | Email updated | `test_should_update_user_email_when_changed_on_live` |
| ✅ | Display name updated | `test_should_update_user_display_name_when_changed_on_live` |
| ✅ | Avatar updated | `test_should_update_user_avatar_when_changed_on_live` |
| ✅ | Avatar removed | `test_should_remove_user_avatar_when_deleted_on_live` |
| ✅ | Avatar added later | `test_should_add_user_avatar_when_added_on_live_after_initial_import` |
| ✅ | Login creates new user | `test_should_not_update_user_login_when_changed_on_live_and_should_create_new_user` |

#### **TERMS**

| Status | Field | Existing Test |
| ----- | ----- | ----- |
| ✅ | Slug updated | `test_should_update_term_slug_when_changed_on_live` |
| ✅ | Description updated | `test_should_update_term_description_when_changed_on_live` |
| ✅ | Name NOT updated | `test_should_not_update_term_name_when_changed_on_live` |
| ✅ | Parent NOT updated | `test_should_not_update_category_parent_when_changed_on_live` |

## **Summary of Gaps and more Tests to Add**

| \# | Gap | Test to Add |
| ----- | ----- | ----- |
| 1 | Check 3: comment\_count | `test_should_filter_modified_posts_when_comment_count_changed` |
| 2 | Non-attributed taxonomies | `test_should_not_detect_modified_when_taxonomy_not_in_attribution_list` |
| 3 | Locally added terms skip | `test_should_not_flag_modified_when_local_term_has_no_attribution_meta` |
| 4 | Postmeta-only changes | `test_should_not_detect_modified_when_only_postmeta_changed` |
| 5 | Comment-only changes | `test_should_not_detect_modified_when_only_comments_changed` |
| 6 | Attachments excluded | `test_should_not_detect_attachments_as_modified_per_mdcs` |
| 7 | Block IDs on reimport | `test_reimport_should_update_block_attachment_ids` |

---

## 5. Faster posts deletion
Instead of deleting modified posts with `wp_post_delete()`, now using batched direct queries, which make the deletion much faster.

---

## 6. Cleaner CLI messages
```
'There are %d total objects remaining on local without any `%s*` metas. See %s for full IDs. If this is 
new local content from Newspackification, it is perfectly safe to continue. Otherwise see README 
and the `attribute-ids` command to set the "old ID and source hostname" metas if this content 
belongs to the same source hostname (e.g. was migrated by some other migration tool).'`
```
leaving just a shorter version of this, without any followup (prompt) required from user.

---

- [x] confirmed that PHPCS has been run
