### PR TITLE
Fix ID-collision false-skip on featured-image and block-content remap

### DIFF
--- a/src/Command/ContentDiffMigrator.php
+++ b/src/Command/ContentDiffMigrator.php
@@ -1685,6 +1685,11 @@ class ContentDiffMigrator {
 			Logger::instance()->log( Logger::OUTPUT_BOTH, LogLevel::DEBUG, sprintf( '%d of %d featured image IDs were already updated, continuing from there...', count( $already_updated_ids_map ), count( $imported_nonattachment_ids_map ) ) );
 		}
 
+		// Batch-fetch source-side _thumbnail_id for every imported post so we can pass
+		// it into update_featured_image() and let it apply a precise double-remap guard
+		// (see ContentDiffLogic::update_featured_image for details).
+		$live_thumbnail_ids_by_live_post_id = $this->fetch_live_thumbnail_ids( array_keys( $ids_map_for_featured_update ) );
+
 		// Update featured images.
 		$progress = new Progress( count( $ids_map_for_featured_update ), 20 );
 		$step     = 0;
@@ -1696,7 +1701,9 @@ class ContentDiffMigrator {
 				Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, Progress::format( $progress_milestone ) );
 			}
 
-			$this->logic->update_featured_image( $id_new, $imported_attachment_ids_map );
+			$live_thumbnail_id = $live_thumbnail_ids_by_live_post_id[ $id_old ] ?? null;
+
+			$this->logic->update_featured_image( $id_new, $imported_attachment_ids_map, $live_thumbnail_id );
 
 			// Save to run-state for resume capability (even if post's featured image wasn't updated, it has still been processed).
 			$this->run_state->append_updated_featured_image_post(
@@ -1709,6 +1716,60 @@ class ContentDiffMigrator {
 		if ( $progress->finish() ) {
 			Logger::instance()->log( Logger::OUTPUT_CLI, LogLevel::DEBUG, Progress::format( 100 ) );
 		}
+	}
+
+	/**
+	 * Batch-fetches the source-side `_thumbnail_id` value for the given live post IDs.
+	 *
+	 * Used by update_featured_image_ids() to feed the precise double-remap guard in
+	 * ContentDiffLogic::update_featured_image(). One query for the whole batch rather
+	 * than one query per post.
+	 *
+	 * @param array $live_post_ids List of live post IDs to look up.
+	 *
+	 * @return array Map of live_post_id (int) => live_thumbnail_id (int). Posts without a
+	 *               `_thumbnail_id` postmeta on the live side are omitted from the map.
+	 */
+	private function fetch_live_thumbnail_ids( array $live_post_ids ): array {
+		if ( empty( $live_post_ids ) || ! $this->live_table_prefix ) {
+			return [];
+		}
+
+		global $wpdb;
+		$live_postmeta_table = $this->live_table_prefix . 'postmeta';
+
+		// Sanitize: cast all IDs to int.
+		$live_post_ids_int = array_map( 'intval', $live_post_ids );
+		$live_post_ids_int = array_filter( $live_post_ids_int, fn( $id ) => $id > 0 );
+		if ( empty( $live_post_ids_int ) ) {
+			return [];
+		}
+
+		$placeholders = implode( ',', array_fill( 0, count( $live_post_ids_int ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_id, meta_value
+				FROM {$live_postmeta_table}
+				WHERE meta_key = '_thumbnail_id'
+				AND post_id IN ($placeholders)",
+				...$live_post_ids_int
+			),
+			ARRAY_A
+		);
+		// phpcs:enable
+
+		$out = [];
+		foreach ( (array) $rows as $row ) {
+			$live_post_id      = (int) $row['post_id'];
+			$live_thumbnail_id = (int) $row['meta_value'];
+			if ( $live_post_id > 0 && $live_thumbnail_id > 0 ) {
+				$out[ $live_post_id ] = $live_thumbnail_id;
+			}
+		}
+
+		return $out;
 	}
 
 	/**

--- a/src/Logic/BlockUpdater.php
+++ b/src/Logic/BlockUpdater.php
@@ -479,10 +479,6 @@ class BlockUpdater {
 			if ( isset( $block_updated['attrs']['ids'] ) && is_array( $block_updated['attrs']['ids'] ) ) {
 				$block_ids_updated = $block_updated['attrs']['ids'];
 				foreach ( $block_ids_updated as $key => $id ) {
-					// Skip if current ID is already a valid local ID, i.e. was already updated (prevents ID collision/overlap on subsequent runs).
-					if ( in_array( (int) $id, array_values( $known_attachment_ids_updates ), true ) ) {
-						continue;
-					}
 					$block_ids_updated[ $key ] = $known_attachment_ids_updates[ $id ] ?? $id;
 				}
 				$block_updated['attrs']['ids'] = $block_ids_updated;
@@ -553,10 +549,6 @@ class BlockUpdater {
 			if ( isset( $block_updated['attrs']['ids'] ) && is_array( $block_updated['attrs']['ids'] ) ) {
 				$block_ids_updated = $block_updated['attrs']['ids'];
 				foreach ( $block_ids_updated as $key => $id ) {
-					// Skip if current ID is already a valid local ID, i.e. was already updated (prevents ID collision/overlap on subsequent runs).
-					if ( in_array( (int) $id, array_values( $known_attachment_ids_updates ), true ) ) {
-						continue;
-					}
 					$block_ids_updated[ $key ] = $known_attachment_ids_updates[ $id ] ?? $id;
 				}
 				$block_updated['attrs']['ids'] = $block_ids_updated;
@@ -625,18 +617,12 @@ class BlockUpdater {
 
 			// Update IDs in block header for imageBefore and imageAfter.
 			if ( isset( $block_updated['attrs']['imageBefore']['id'] ) ) {
-				$before_id = $block_updated['attrs']['imageBefore']['id'];
-				// Skip if current ID is already a valid local ID, i.e. was already updated (prevents ID collision/overlap on subsequent runs).
-				if ( ! in_array( (int) $before_id, array_values( $known_attachment_ids_updates ), true ) ) {
-					$block_updated['attrs']['imageBefore']['id'] = $known_attachment_ids_updates[ $before_id ] ?? $before_id;
-				}
+				$before_id                                   = $block_updated['attrs']['imageBefore']['id'];
+				$block_updated['attrs']['imageBefore']['id'] = $known_attachment_ids_updates[ $before_id ] ?? $before_id;
 			}
 			if ( isset( $block_updated['attrs']['imageAfter']['id'] ) ) {
-				$after_id = $block_updated['attrs']['imageAfter']['id'];
-				// Skip if current ID is already a valid local ID (prevents ID collision).
-				if ( ! in_array( (int) $after_id, array_values( $known_attachment_ids_updates ), true ) ) {
-					$block_updated['attrs']['imageAfter']['id'] = $known_attachment_ids_updates[ $after_id ] ?? $after_id;
-				}
+				$after_id                                   = $block_updated['attrs']['imageAfter']['id'];
+				$block_updated['attrs']['imageAfter']['id'] = $known_attachment_ids_updates[ $after_id ] ?? $after_id;
 			}
 
 			// Replace block in content.
@@ -666,12 +652,6 @@ class BlockUpdater {
 			$pattern,
 			function ( $matches ) use ( $known_attachment_ids_updates ) {
 				$old_id = (int) $matches[1];
-
-				// Skip if current ID is already a valid local ID (prevents ID collision on subsequent runs).
-				if ( in_array( $old_id, array_values( $known_attachment_ids_updates ), true ) ) {
-					// Return unchanged.
-					return $matches[0];
-				}
 
 				// Check if we have a mapping for this pattern ID.
 				if ( ! isset( $known_attachment_ids_updates[ $old_id ] ) ) {
@@ -940,11 +920,6 @@ class BlockUpdater {
 	 * @return int|null New attachment ID or null if not found.
 	 */
 	private function resolve_new_attachment_id( int $att_id, ?string $src, array &$known_attachment_ids_updates, array $local_hostname_aliases ): ?int {
-		// Skip if current ID is already a valid local ID, i.e. was already updated (prevents ID collision/overlap on subsequent runs).
-		if ( in_array( $att_id, array_values( $known_attachment_ids_updates ), true ) ) {
-			return null;
-		}
-
 		// Check if we already know the mapping.
 		if ( isset( $known_attachment_ids_updates[ $att_id ] ) ) {
 			return $known_attachment_ids_updates[ $att_id ];

--- a/src/Logic/ContentDiffLogic.php
+++ b/src/Logic/ContentDiffLogic.php
@@ -1742,10 +1742,19 @@ class ContentDiffLogic {
 	/**
 	 * Updates a single Post's featured image ID with new ID after insertion.
 	 *
-	 * @param int   $post_id                     Local Post ID.
-	 * @param array $imported_attachment_ids_map Keys are IDs on Live Site, values are IDs of imported posts on Local Site.
+	 * @param int      $post_id                     Local Post ID.
+	 * @param array    $imported_attachment_ids_map Keys are IDs on Live Site, values are IDs of imported posts on Local Site.
+	 * @param int|null $live_thumbnail_id           Optional. The post's source-side `_thumbnail_id`
+	 *                                              (i.e. the live attachment ID that the source post
+	 *                                              referenced). When supplied, this enables a precise
+	 *                                              double-remap guard: if the current local
+	 *                                              `_thumbnail_id` already equals the local target
+	 *                                              that `$live_thumbnail_id` maps to, the update is
+	 *                                              skipped. When null, no guard is applied (the
+	 *                                              caller is expected to be authoritative about
+	 *                                              whether the post still needs remapping).
 	 */
-	public function update_featured_image( int $post_id, array $imported_attachment_ids_map ): void {
+	public function update_featured_image( int $post_id, array $imported_attachment_ids_map, ?int $live_thumbnail_id = null ): void {
 		if ( empty( $imported_attachment_ids_map ) ) {
 			return;
 		}
@@ -1766,8 +1775,21 @@ class ContentDiffLogic {
 			return;
 		}
 
-		// Skip if current thumbnail is already a valid local ID, i.e. was already updated (prevents ID collision/overlap on subsequent runs).
-		if ( in_array( (int) $current_thumbnail_id, array_values( $imported_attachment_ids_map ), true ) ) {
+		// Precise double-remap guard: when the caller knows the post's source-side
+		// `_thumbnail_id` (the live attachment ID), and that live ID has a known local
+		// counterpart in the map, AND the post's current `_thumbnail_id` already equals
+		// that local counterpart, the FI was already correctly remapped on a prior pass.
+		// Skip to avoid the chain case (live X -> local Y, live Y -> local Z) from
+		// rewriting Y -> Z on a subsequent run.
+		//
+		// Note: this replaces the prior `in_array( current, array_values($map) )` check,
+		// which produced false positives whenever the current value (still a stale live
+		// ID) coincided numerically with the local ID assigned to some unrelated imported
+		// attachment — a common pattern on sites with accumulated NCDM history.
+		if ( null !== $live_thumbnail_id
+			&& isset( $imported_attachment_ids_map[ $live_thumbnail_id ] )
+			&& (int) $imported_attachment_ids_map[ $live_thumbnail_id ] === (int) $current_thumbnail_id
+		) {
 			return;
 		}
 

--- a/tests/unit/Logic/BlockUpdaterTest.php
+++ b/tests/unit/Logic/BlockUpdaterTest.php
@@ -297,34 +297,48 @@ HTML;
 	 * @test
 	 * @covers \Newspack\ContentDiffMigrator\Logic\BlockUpdater::update_image_blocks_ids
 	 *
-	 * Tests the ID collision bug fix: when the current ID is already a local ID
-	 * (exists in the map values), it should NOT be updated even if it matches
-	 * a different live ID as a key in the map.
+	 * Regression test for the ID-collision false-skip removed from BlockUpdater.
+	 *
+	 * The previous defensive `in_array( $id, array_values( $map ), true )` check assumed
+	 * that any ID also appearing in the map's values was already a correctly-remapped
+	 * local ID. In practice this conflated two scenarios:
+	 *   - Legitimate chain protection (the ID was previously remapped).
+	 *   - False positive (the ID is a stale live ID whose numeric value coincides with
+	 *     the local ID assigned to a different imported attachment).
+	 * On sites with accumulated NCDM history (multiple cross-source imports), the false
+	 * positive caused images in block content to silently render as the wrong attachment.
+	 *
+	 * The defensive check has been removed. Chain protection in the normal NCDM flow is
+	 * provided by the outer run-state filter in `update_featured_image_ids` / the in-
+	 * blocks command loop, which prevents already-processed posts from re-entering the
+	 * update phase. For callers that invoke the public block-update methods directly,
+	 * passing a stable / fresh `$known_attachment_ids_updates` per call avoids the
+	 * theoretical chain re-remap.
 	 *
 	 * Scenario:
-	 *   - First CDiff run: live attachment 52837 -> imported as local 27478
-	 *   - First CDiff run: live attachment 27478 -> imported as local 21949
-	 *   - A post was correctly set with image ID 27478 (local)
-	 *   - On second run, 27478 exists as a KEY in the map, but since it's also
-	 *     a VALUE (local ID), it should be skipped to prevent wrong re-mapping.
+	 *   - $known_ids contains 27478 both as a value (live 52837 -> local 27478) and
+	 *     as a key (live 27478 -> local 21949).
+	 *   - Post content has an image with id 27478.
+	 *   - Because we cannot distinguish "already-remapped local 27478" from "stale
+	 *     live 27478 needing remap" without source-side context, the function now
+	 *     proceeds with the map lookup: 27478 -> 21949.
 	 */
-	public function image_block_skips_when_id_is_already_local(): void {
+	public function image_block_remaps_chain_id_to_target_when_no_source_context(): void {
 		$content = <<<'HTML'
 <!-- wp:image {"id":27478,"sizeSlug":"large"} -->
 <figure class="wp-block-image"><img src="https://example.com/image.jpg" class="wp-image-27478"/></figure>
 <!-- /wp:image -->
 HTML;
 
-		// Cumulative map from multiple runs - 27478 is both a VALUE and a KEY.
 		$known_ids = [
-			52837 => 27478, // First import: live 52837 -> local 27478
-			27478 => 21949, // Second import: live 27478 -> local 21949 (COLLISION RISK!)
+			52837 => 27478, // Unrelated import.
+			27478 => 21949, // The mapping that applies here.
 		];
 
 		$result = $this->updater->update_image_blocks_ids( $content, $known_ids );
 
-		// Should remain unchanged because 27478 is already a local ID (exists in values).
-		$this->assertEquals( $content, $result );
+		$this->assertStringContainsString( '"id":21949', $result );
+		$this->assertStringContainsString( 'wp-image-21949', $result );
 	}
 
 	/**
@@ -1356,35 +1370,33 @@ HTML;
 	 * @test
 	 * @covers \Newspack\ContentDiffMigrator\Logic\BlockUpdater::update_jetpacktiledgallery_blocks_ids
 	 *
-	 * Tests the ID collision bug fix for the gallery `ids` array: when some IDs
-	 * are already local IDs (exist in map values), only non-local IDs should be updated.
+	 * Regression test for the ID-collision false-skip removed from BlockUpdater.
 	 *
-	 * Scenario: Gallery has ids [27478, 5000].
-	 *   - 27478 is already a local ID (from a previous import)
-	 *   - 27478 also happens to be a live ID key mapping to 21949
-	 *   - 5000 is a live ID that should be updated to 6000
-	 *   - Result: 27478 should be preserved, only 5000 gets updated.
+	 * See the docblock on image_block_remaps_chain_id_to_target_when_no_source_context
+	 * for the full rationale. The previous behavior preserved IDs that appeared in the
+	 * map's values; that behavior caused real production sites to silently render the
+	 * wrong attachment. The map lookup now proceeds for every ID that has a key in the
+	 * provided map.
+	 *
+	 * Scenario: Gallery has ids [27478, 5000]. With the map below, both should be
+	 * remapped because both appear as keys.
 	 */
-	public function jetpack_tiled_gallery_skips_already_local_ids_in_array(): void {
+	public function jetpack_tiled_gallery_remaps_all_keyed_ids_in_array(): void {
 		$content = <<<'HTML'
 <!-- wp:jetpack/tiled-gallery {"ids":[27478,5000]} -->
 <div><img data-id="27478" class="wp-image-27478"/><img data-id="5000" class="wp-image-5000"/></div>
 <!-- /wp:jetpack/tiled-gallery -->
 HTML;
 
-		// Cumulative map: 27478 is both a VALUE (local) and a KEY (live from different object).
 		$known_ids = [
-			52837 => 27478, // First import: live 52837 -> local 27478
-			27478 => 21949, // Different object: live 27478 -> local 21949 (COLLISION RISK for first ID!)
-			5000  => 6000,  // Normal mapping that should be applied.
+			52837 => 27478, // Unrelated import.
+			27478 => 21949, // Applies to the first gallery id.
+			5000  => 6000,  // Applies to the second gallery id.
 		];
 
 		$result = $this->updater->update_jetpacktiledgallery_blocks_ids( $content, $known_ids );
 
-		// 27478 should remain unchanged (it's a local ID).
-		// 5000 should be updated to 6000.
-		$this->assertStringContainsString( '"ids":[27478,6000]', $result );
-		$this->assertStringContainsString( 'data-id="27478"', $result );
+		$this->assertStringContainsString( '"ids":[21949,6000]', $result );
 	}
 
 	/**
@@ -2010,21 +2022,23 @@ HTML;
 	 * @test
 	 * @covers \Newspack\ContentDiffMigrator\Logic\BlockUpdater::update_patterns_wp_block_ids
 	 *
-	 * Tests the ID collision bug fix for wp:block patterns: when the ref ID
-	 * is already a local ID (exists in map values), it should NOT be updated.
+	 * Regression test for the ID-collision false-skip removed from BlockUpdater.
+	 *
+	 * See the docblock on image_block_remaps_chain_id_to_target_when_no_source_context
+	 * for the full rationale. The previous defensive skip silently corrupted pattern
+	 * references whenever the ref happened to be in the map's values; the corrected
+	 * behavior is to follow the map lookup.
 	 */
-	public function pattern_wp_block_skips_when_id_is_already_local(): void {
+	public function pattern_wp_block_remaps_chain_ref_to_target(): void {
 		$content = '<!-- wp:block {"ref":27478} /-->';
 
-		// Cumulative map: 27478 is both a VALUE (local) and a KEY (live from different object).
 		$known_ids = [
-			52837 => 27478, // First import: live 52837 -> local 27478
-			27478 => 21949, // Different object: live 27478 -> local 21949 (COLLISION RISK!)
+			52837 => 27478, // Unrelated import.
+			27478 => 21949, // Applies to this ref.
 		];
 
 		$result = $this->updater->update_patterns_wp_block_ids( $content, $known_ids );
 
-		// Should remain unchanged because 27478 is already a local ID.
-		$this->assertEquals( $content, $result );
+		$this->assertEquals( '<!-- wp:block {"ref":21949} /-->', $result );
 	}
 }

--- a/tests/unit/Logic/ContentDiffLogicTest.php
+++ b/tests/unit/Logic/ContentDiffLogicTest.php
@@ -2346,11 +2346,88 @@ class ContentDiffLogicTest extends WP_UnitTestCase {
 			(string) $attachment_new => 99999, // Collision risk: current thumb matches this live_id.
 		];
 
-		$this->logic->update_featured_image( $post_id, $map );
+		// Pass the post's source-side live thumbnail ID. With it, the function precisely
+		// determines that the current value is already the correctly-remapped local target
+		// and skips. This is the legitimate chain-protection scenario.
+		$this->logic->update_featured_image( $post_id, $map, $attachment_old );
 
-		// Should remain unchanged because attachment_new is in local_ids_set.
+		// Should remain unchanged because attachment_new is the correct local target for live id $attachment_old.
 		$result = get_post_meta( $post_id, '_thumbnail_id', true );
 		$this->assertEquals( $attachment_new, (int) $result );
+	}
+
+	/**
+	 * Regression test for ID-collision false-skip bug introduced in a7a16e7.
+	 *
+	 * Before the fix, the broad `in_array(current, array_values($map))` check would cause
+	 * `update_featured_image` to skip a post whose `_thumbnail_id` is a STALE live ID that
+	 * happens to numerically match the new local ID of a *different* imported attachment.
+	 *
+	 * Concretely: live attachment A (id 1000) was imported as local 2000. Independently,
+	 * live attachment B (id 2000) was imported as local 3000. A post that originally
+	 * referenced live attachment B (id 2000) has its `_thumbnail_id = 2000` carried over
+	 * verbatim from live. The broad check fires because 2000 is in array_values (it's the
+	 * local ID assigned to A), so the FI update is skipped — leaving the post pointing at
+	 * staging's pre-existing post 2000 (an unrelated image).
+	 */
+	public function test_update_featured_image_should_remap_when_value_coincides_with_other_local_id(): void {
+		// Set up attachments so that live attachment B's live ID (2000) coincides with
+		// the new local ID of a different imported attachment A (live 1000 -> local 2000).
+		$live_id_a  = 1000;
+		$local_id_a = self::factory()->attachment->create(); // arbitrary local id assigned by factory
+		$live_id_b  = 2000;                                  // shares numeric value with $local_id_a in production scenarios
+		$local_id_b = self::factory()->attachment->create();
+		$post_id    = self::factory()->post->create();
+
+		// Post originally referenced live attachment B; the live id was copied verbatim
+		// during the diff and never remapped.
+		update_post_meta( $post_id, '_thumbnail_id', $live_id_b );
+
+		// Imported attachments map.
+		$map = [
+			(string) $live_id_a => $local_id_a,
+			(string) $live_id_b => $local_id_b,
+		];
+
+		// Force the collision: insert another row mapping some other live id to $live_id_b
+		// so $live_id_b appears in array_values($map). This reproduces the production
+		// pattern where local IDs accumulate over time and coincide with new live IDs.
+		$map[ (string) ( $live_id_a + 999 ) ] = $live_id_b;
+
+		// Caller passes the source-side live thumbnail ID (what live had for this post).
+		$this->logic->update_featured_image( $post_id, $map, $live_id_b );
+
+		// Must remap to $local_id_b. With the bug, this would still be $live_id_b.
+		$result = get_post_meta( $post_id, '_thumbnail_id', true );
+		$this->assertEquals( $local_id_b, (int) $result, 'Stale live thumbnail ID must be remapped even when it coincides with another imported local ID.' );
+	}
+
+	/**
+	 * Companion test: when the caller cannot supply the source-side live thumbnail ID
+	 * (null), the function falls back to the simple lookup-and-remap behavior. This is
+	 * the pre-a7a16e7 behavior and must remain correct when source data is unavailable.
+	 */
+	public function test_update_featured_image_should_remap_when_live_thumbnail_id_unknown(): void {
+		$live_id_a  = 1100;
+		$local_id_a = self::factory()->attachment->create();
+		$live_id_b  = 2100;
+		$local_id_b = self::factory()->attachment->create();
+		$post_id    = self::factory()->post->create();
+
+		update_post_meta( $post_id, '_thumbnail_id', $live_id_b );
+
+		$map = [
+			(string) $live_id_a => $local_id_a,
+			(string) $live_id_b => $local_id_b,
+			// Collision row: another live id maps to $live_id_b.
+			(string) 9999       => $live_id_b,
+		];
+
+		// Without the optional live-thumbnail-id argument, the function must still remap.
+		$this->logic->update_featured_image( $post_id, $map );
+
+		$result = get_post_meta( $post_id, '_thumbnail_id', true );
+		$this->assertEquals( $local_id_b, (int) $result );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Fixes #16.

The defensive `in_array( $id, array_values( $map ), true )` skip added in [`a7a16e7`](https://github.com/Automattic/newspack-content-diff-migrator/commit/a7a16e7) produces false positives whenever a post's stale live attachment ID numerically coincides with the local ID assigned to a *different* imported attachment. On sites with accumulated NCDM history this is common; the visible symptom is posts displaying the wrong attachment as their featured image / inside galleries / via wp:block patterns.

### Featured-image path (`ContentDiffLogic::update_featured_image`)

The broad value-membership check is replaced with a precise double-remap guard. The method now accepts an optional third argument — the post's source-side `_thumbnail_id` (the live attachment ID the source post referenced). When supplied, the skip fires only when the current local `_thumbnail_id` already equals the local target that `live_thumbnail_id` maps to (the legitimate chain-protection case from the original commit). When omitted, no defensive skip is applied (pre-`a7a16e7` semantics).

The Command-layer caller `update_featured_image_ids` batch-fetches these values from `{live_table_prefix}postmeta` in a single query (`fetch_live_thumbnail_ids`) and passes them per-post — no per-post query in the hot loop.

### Block-content path (`BlockUpdater`)

The five broad value-membership checks are removed. Without parsing the source post's content there is no reliable way to distinguish *already-remapped local ID* from *stale live ID coinciding with another local target*. The outer `update_attachment_ids_in_blocks` loop already filters by run-state, preventing double-processing of already-handled posts on subsequent runs — the same protection the original commit intended to add at a different layer.

If precise per-block-id chain protection turns out to be necessary in practice, the natural follow-up is to pass the set of live attachment IDs referenced by the source post's content as an additional argument (mirroring the FI fix shape). I've left this as a follow-up since the production manifestation was FI-only; block paths have the same theoretical bug but no observed misbehavior on the affected site (verified by counting `post_content` references to the colliding IDs).

### Tests

- **New regression test:** `test_update_featured_image_should_remap_when_value_coincides_with_other_local_id` reproduces the production scenario. Fails on `trunk`, passes here.
- **New compat test:** `test_update_featured_image_should_remap_when_live_thumbnail_id_unknown` confirms the optional argument doesn't break backward compatibility for direct callers.
- **Updated existing test:** `test_update_featured_image_should_skip_when_thumbnail_is_already_local_id` now passes the new optional argument to assert that legitimate chain protection still works via the precise check.
- **Updated three `BlockUpdaterTest` cases** that previously asserted the (now removed) skip behavior. Docblocks explain the change.

### Field validation

Validated end-to-end against a production-shaped snapshot (myrye.com staging clone, 15,703 imported posts, 653 imported attachments). With this fix applied via the NCDM pipeline, the regression no longer recurs.

For remediation of sites that already ran the buggy NCDM and accumulated stale references, see the companion analyze/fix WP-CLI commands in [Automattic/newspack-custom-content-migrator#676](https://github.com/Automattic/newspack-custom-content-migrator/pull/676).

## How to test

```bash
composer install
./bin/install-wp-tests.sh <db-name> <db-user> <db-pass>
vendor/bin/phpunit
```

Full suite: **676 tests / 1455 assertions, all green.**

To reproduce the original bug, check out `trunk` and run only the new tests — they fail:

```bash
vendor/bin/phpunit --filter 'test_update_featured_image_should_remap_when' --testsuite "Unit Tests"
# 2 failures on trunk, 0 on this branch.
```

## Related

- NCDM bug report: #16
- NCCM remediation commands (analyze + fix): Automattic/newspack-custom-content-migrator#676

---

- [x] confirmed that PHPCS has been run