### PR TITLE
chore: pin third-party GitHub Actions to SHAs + enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,7 +21,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: "8.1"
                   extensions: mbstring, mysqli


### PR DESCRIPTION
Two-in-one hardening:

1. Pin third-party GitHub Actions in this repo to commit SHAs (tag preserved as trailing comment).
2. Add Dependabot `github-actions` config (weekly, grouped into `actions-minor-patch` and `actions-major`, with cooldown).

Tracking: DEVPROD-1072.
